### PR TITLE
fix: train-supervised validation bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -381,7 +381,7 @@ if __name__ == "__main__":
         )
         logger.info("Validation sampler created successfully.")
 
-    elif args.mode == "eval":
+    if args.mode == "eval":
         if create_state_fn is None or compute_estimate_fn is None:
             raise ValueError(
                 "create_state_fn and compute_estimate_fn must be provided "


### PR DESCRIPTION
## Summary
Fix the `train-supervised` mode dispatch when validation is configured.

## What changed
The validation-sampler setup block in `src/main.py` was part of the same `if/elif` chain as the main mode dispatch. When `args.mode == "train-supervised"` and `validation_settings` was present, execution entered the validation block and skipped the later `train-supervised` branch entirely.

This change makes the `eval` dispatch start a new conditional chain, so validation setup can happen first without preventing the requested mode from running.

## Root cause
Optional validation initialization was incorrectly coupled to mutually exclusive mode dispatch.

## Validation
- `git diff --check`
- `uv run python -m py_compile src/main.py src/train_supervised.py`
