### PR TITLE
fix: reintroduce estimator API rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ There you can also find help if you have any issues installing Flow Gym.
 ```python
 from flowgym.make import make_estimator
 # Define the config (or load from YAML)
-model_config = {
+estimator_config = {
     "estimator": "dis_jax",
     "estimate_type": "flow",
     "config": {"jit": True, ..., },
 }
 
 # Create the estimator and associated functions
-trained_state, create_state_fn, compute_estimate_fn, model = make_estimator(
-    model_config=model_config,
+trained_state, create_state_fn, compute_estimate_fn, estimator = make_estimator(
+    estimator_config=estimator_config,
     image_shape=image_shape
 )
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -107,6 +107,6 @@ Tests are located in the `tests/` directory and largely mirror the structure of 
 - Update the relevant `eval_*` function in `src/eval.py` to include the new metric.
 
 ### Changing configuration
-- All default settings reside in `src/flowgym/config/`. When running experiments, pass a customized YAML via the `--model` or `--dataset` flags in `main.py`.
+- All default settings reside in `src/flowgym/config/`. When running experiments, pass a customized YAML via the `--estimator` or `--dataset` flags in `main.py`.
 
 ---

--- a/examples/10_caching.py
+++ b/examples/10_caching.py
@@ -1,4 +1,4 @@
-"""Example of how to use caching with DIS model and temporary .mat files."""
+"""Example of how to use caching with DIS estimator and temporary .mat files."""
 
 import os
 import subprocess
@@ -20,7 +20,7 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
         temp_dir: Temporary directory path for data and configs.
 
     Returns:
-        Tuple of (dataset_path, model_path) for the created configs.
+        Tuple of (dataset_path, estimator_path) for the created configs.
     """
 
     data_dir = Path(temp_dir) / "test"
@@ -92,8 +92,8 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
     with open(dataset_path, "w") as f:
         yaml.dump(dataset_config, f)
 
-    # 2. Model Config
-    model_config = {
+    # 2. Estimator Config
+    estimator_config = {
         "estimator": "dis_jax",
         "estimate_type": "flow",
         "config": {
@@ -103,19 +103,19 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
         },
     }
 
-    model_path = Path(temp_dir) / "model.yaml"
-    with open(model_path, "w") as f:
-        yaml.dump(model_config, f)
+    estimator_path = Path(temp_dir) / "estimator.yaml"
+    with open(estimator_path, "w") as f:
+        yaml.dump(estimator_config, f)
 
-    return dataset_path, model_path
+    return dataset_path, estimator_path
 
 
-def run_main(dataset_path: Path, model_path: Path, description: str):
+def run_main(dataset_path: Path, estimator_path: Path, description: str):
     """Run src/main.py via subprocess.
 
     Args:
         dataset_path: Path to dataset configuration YAML.
-        model_path: Path to model configuration YAML.
+        estimator_path: Path to estimator configuration YAML.
         description: Description of this run for logging.
 
     Returns:
@@ -130,7 +130,7 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
         "-m",
         "src.main",
         "--estimator",
-        str(model_path),
+        str(estimator_path),
         "--dataset",
         str(dataset_path),
         "--mode",
@@ -165,14 +165,16 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
 
 
 def run_example():
-    print("=== DIS Model Caching Example ===")
+    print("=== DIS Estimator Caching Example ===")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         print(f"Using temporary directory: {temp_dir}")
-        dataset_path, model_path = setup_configs(temp_dir)
+        dataset_path, estimator_path = setup_configs(temp_dir)
 
         # Run 1: Cold Start
-        duration_1 = run_main(dataset_path, model_path, "Run 1: Cold Start")
+        duration_1 = run_main(
+            dataset_path, estimator_path, "Run 1: Cold Start"
+        )
 
         # Modify config to use warm_start="all" for Run 2
         # We rewrite the dataset yaml
@@ -186,7 +188,9 @@ def run_example():
             yaml.dump(config, f)
 
         # Run 2: Warm Start
-        duration_2 = run_main(dataset_path, model_path, "Run 2: Warm Start")
+        duration_2 = run_main(
+            dataset_path, estimator_path, "Run 2: Warm Start"
+        )
 
         # Analysis
         if duration_2 < duration_1:

--- a/examples/10_caching.py
+++ b/examples/10_caching.py
@@ -129,7 +129,7 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
         "python",
         "-m",
         "src.main",
-        "--model",
+        "--estimator",
         str(model_path),
         "--dataset",
         str(dataset_path),

--- a/examples/11_caching.py
+++ b/examples/11_caching.py
@@ -1,4 +1,4 @@
-"""Example of how to use caching with RAFT model and temporary .mat files."""
+"""Example of how to use caching with RAFT estimator and temporary .mat files."""
 
 import os
 import subprocess
@@ -20,7 +20,7 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
         temp_dir: Temporary directory path for data and configs.
 
     Returns:
-        Tuple of (dataset_path, model_path) for the created configs.
+        Tuple of (dataset_path, estimator_path) for the created configs.
     """
 
     data_dir = Path(temp_dir) / "test"
@@ -92,15 +92,15 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
     with open(dataset_path, "w") as f:
         yaml.dump(dataset_config, f)
 
-    # 2. Model Config
-    model_config = {
+    # 2. Estimator Config
+    estimator_config = {
         "estimator": "raft_jax",
         "estimate_type": "flow",
         "config": {
             "iters": 4,  # Low iters for speed in example
             "patch_size": 32,
             "patch_stride": 32,  # Increased stride for speed/memory
-            "hidden_dim": 64,  # Small model
+            "hidden_dim": 64,  # Small estimator
             "context_dim": 64,
             "corr_levels": 2,
             "corr_radius": 2,
@@ -112,19 +112,19 @@ def setup_configs(temp_dir: str) -> tuple[Path, Path]:
         },
     }
 
-    model_path = Path(temp_dir) / "model.yaml"
-    with open(model_path, "w") as f:
-        yaml.dump(model_config, f)
+    estimator_path = Path(temp_dir) / "estimator.yaml"
+    with open(estimator_path, "w") as f:
+        yaml.dump(estimator_config, f)
 
-    return dataset_path, model_path
+    return dataset_path, estimator_path
 
 
-def run_main(dataset_path: Path, model_path: Path, description: str):
+def run_main(dataset_path: Path, estimator_path: Path, description: str):
     """Run src/main.py via subprocess.
 
     Args:
         dataset_path: Path to dataset configuration YAML.
-        model_path: Path to model configuration YAML.
+        estimator_path: Path to estimator configuration YAML.
         description: Description of this run for logging.
 
     Returns:
@@ -139,7 +139,7 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
         "-m",
         "src.main",
         "--estimator",
-        str(model_path),
+        str(estimator_path),
         "--dataset",
         str(dataset_path),
         "--mode",
@@ -174,21 +174,23 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
 
     # Verify that cache ID was updated
     for line in result.stderr.splitlines() + result.stdout.splitlines():
-        if "Updated cache_id with model suffix" in line:
+        if "Updated cache_id with estimator suffix" in line:
             print(f"Verified: {line.strip()}")
 
     return duration
 
 
 def run_example():
-    print("=== RAFT Model Caching Example ===")
+    print("=== RAFT Estimator Caching Example ===")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         print(f"Using temporary directory: {temp_dir}")
-        dataset_path, model_path = setup_configs(temp_dir)
+        dataset_path, estimator_path = setup_configs(temp_dir)
 
         # Run 1: Cold Start
-        duration_1 = run_main(dataset_path, model_path, "Run 1: Cold Start")
+        duration_1 = run_main(
+            dataset_path, estimator_path, "Run 1: Cold Start"
+        )
 
         # Modify config to use warm_start="all" for Run 2
         with open(dataset_path) as f:
@@ -201,7 +203,9 @@ def run_example():
             yaml.dump(config, f)
 
         # Run 2: Warm Start
-        duration_2 = run_main(dataset_path, model_path, "Run 2: Warm Start")
+        duration_2 = run_main(
+            dataset_path, estimator_path, "Run 2: Warm Start"
+        )
 
         # Analysis
         if duration_2 < duration_1:

--- a/examples/11_caching.py
+++ b/examples/11_caching.py
@@ -138,7 +138,7 @@ def run_main(dataset_path: Path, model_path: Path, description: str):
         "python",
         "-m",
         "src.main",
-        "--model",
+        "--estimator",
         str(model_path),
         "--dataset",
         str(dataset_path),

--- a/experiments/piv-admm/experiment1.py
+++ b/experiments/piv-admm/experiment1.py
@@ -23,7 +23,7 @@ RUN_CMD = [
     "python",
     "-m",
     "src.main",
-    "--model",
+    "--estimator",
     str(CONFIG_PATH),
     "--dataset",
     "src/flowgym/config/piv_dataset_class1_eval_original.yaml",

--- a/src/compare.py
+++ b/src/compare.py
@@ -40,9 +40,6 @@ def compare_performances_on_batches(
 ) -> Metrics:
     """Compare the estimator on two batches using the provided estimator.
 
-    if key is None:
-        key = jax.random.PRNGKey(0)
-
     Args:
         estimator: The estimator to evaluate.
         trained_state: The trained state of the estimator.
@@ -134,9 +131,6 @@ def comparison(
     key: PRNGKey | None = None,
 ) -> None:
     """Compare the flow field between real and synthetic images.
-
-    if key is None:
-        key = jax.random.PRNGKey(0)
 
     Args:
         estimator_config: Configuration of the estimator.

--- a/src/compare.py
+++ b/src/compare.py
@@ -30,7 +30,7 @@ logger = get_logger(__name__, with_metrics=True)
 
 
 def compare_performances_on_batches(
-    model: Estimator,
+    estimator: Estimator,
     trained_state: EstimatorTrainableState,
     create_state_fn: Callable,
     compute_flow_fn: Callable,
@@ -44,8 +44,8 @@ def compare_performances_on_batches(
         key = jax.random.PRNGKey(0)
 
     Args:
-        model: The model to evaluate.
-        trained_state: The trained state of the model.
+        estimator: The estimator to evaluate.
+        trained_state: The trained state of the estimator.
         create_state_fn: Function to create the state.
         compute_flow_fn: Function to compute the flow.
         batch1: The first batch of images.
@@ -94,8 +94,8 @@ def compare_performances_on_batches(
     t2 = time.time() - t2
 
     # Post process the metrics
-    metrics1 = model.process_metrics(metrics1)
-    metrics2 = model.process_metrics(metrics2)
+    metrics1 = estimator.process_metrics(metrics1)
+    metrics2 = estimator.process_metrics(metrics2)
 
     flow_field_1 = estimation_state1["estimates"][:, -1]
     flow_field_2 = estimation_state2["estimates"][:, -1]
@@ -124,10 +124,10 @@ def compare_performances_on_batches(
 
 
 def comparison(
-    model_config: dict,
+    estimator_config: dict,
     sampler1: SyntheticImageSampler,
     sampler2: RealImageSampler,
-    model: Estimator,
+    estimator: Estimator,
     create_state_fn: Callable,
     compute_estimate_fn: Callable,
     trainable_state: EstimatorTrainableState,
@@ -139,21 +139,21 @@ def comparison(
         key = jax.random.PRNGKey(0)
 
     Args:
-        model_config: Configuration of the model.
+        estimator_config: Configuration of the estimator.
         sampler1: The image sampler for comparison.
         sampler2: The second image sampler for comparison.
-        model: The model to evaluate.
+        estimator: The estimator to evaluate.
         create_state_fn: Function to create the state.
         compute_estimate_fn: Function to compute the estimate.
-        trainable_state: The trained state of the model.
+        trainable_state: The trained state of the estimator.
         key: Random key for JAX operations.
 
     Raises:
         ValueError: If estimate_type is not 'flow'.
     """
-    if model_config["estimate_type"] != "flow":
+    if estimator_config["estimate_type"] != "flow":
         raise ValueError(
-            f"Invalid estimate type: {model_config['estimate_type']}. "
+            f"Invalid estimate type: {estimator_config['estimate_type']}. "
             "Only 'flow' is supported for full comparison."
         )
 
@@ -173,7 +173,7 @@ def comparison(
                 break
 
             metrics = compare_performances_on_batches(
-                model=model,
+                estimator=estimator,
                 trained_state=trainable_state,
                 create_state_fn=create_state_fn,
                 compute_flow_fn=compute_estimate_fn,

--- a/src/compare.py
+++ b/src/compare.py
@@ -13,7 +13,7 @@ from synthpix.sampler import RealImageSampler, SyntheticImageSampler
 
 import flowgym
 
-# Models
+# Estimators
 from flowgym.common.base import Estimator, EstimatorTrainableState
 
 # Utils

--- a/src/eval.py
+++ b/src/eval.py
@@ -14,7 +14,7 @@ from goggles.shutdown import GracefulShutdown
 from synthpix import SynthpixBatch
 from synthpix.sampler import Sampler
 
-# Models
+# Estimators
 from flowgym.common.base import Estimator, EstimatorTrainableState
 from flowgym.common.evaluation import loss_supervised_density
 from flowgym.training.caching import CacheManager, enrich_batch
@@ -30,7 +30,8 @@ logger = get_logger(__name__, with_metrics=True)
 
 
 def eval_flow(
-    model: Estimator,
+    estimator: Estimator,
+    *,
     trained_state: EstimatorTrainableState,
     create_state_fn: CompiledCreateStateFn,
     compute_flow_fn: CompiledComputeEstimateFn,
@@ -38,11 +39,11 @@ def eval_flow(
     key: PRNGKey | None = None,
     cache_payload: CachePayload | None = None,
 ) -> Metrics:
-    """Evaluate the model using the provided sampler.
+    """Evaluate the estimator using the provided sampler.
 
     Args:
-        model: The model to evaluate.
-        trained_state: The trained state of the model.
+        estimator: The estimator to evaluate.
+        trained_state: The trained state of the estimator.
         create_state_fn: Function to create the state.
         compute_flow_fn: Function to compute the flow.
         batch: A batch of images and flow fields.
@@ -65,8 +66,8 @@ def eval_flow(
     # Compute the flow field estimate
     t = time.time()
 
-    if model.is_oracle():
-        # If the model is an oracle, provide the ground truth flow field
+    if estimator.is_oracle():
+        # If the estimator is an oracle, provide the ground truth flow field
         estimation_state["estimates"] = (
             estimation_state["estimates"].at[:, -1].set(flow_field_gt)
         )
@@ -80,7 +81,7 @@ def eval_flow(
     t = time.time() - t
 
     # Post process the metrics
-    metrics = model.process_metrics(metrics)
+    metrics = estimator.process_metrics(metrics)
 
     # Extract the flow field from the estimation state
     flow_field = estimation_state["estimates"][:, -1]
@@ -106,7 +107,8 @@ def eval_flow(
 
 
 def eval_density(
-    model: Estimator,
+    estimator: Estimator,
+    *,
     trained_state: EstimatorTrainableState | None,
     create_state_fn: Callable,
     compute_estimate_fn: Callable,
@@ -114,11 +116,11 @@ def eval_density(
     key: PRNGKey | None = None,
     cache_payload: CachePayload | None = None,
 ) -> Metrics:
-    """Evaluate the model using the provided sampler.
+    """Evaluate the estimator using the provided sampler.
 
     Args:
-        model: The model to evaluate.
-        trained_state: The trained state of the model.
+        estimator: The estimator to evaluate.
+        trained_state: The trained state of the estimator.
         create_state_fn: Function to create the state.
         compute_estimate_fn: Function to compute the estimate.
         batch: A batch of images and flow fields.
@@ -152,7 +154,7 @@ def eval_density(
     t = time.time() - t
 
     # Post process the metrics
-    metrics = model.process_metrics(metrics)
+    metrics = estimator.process_metrics(metrics)
 
     # Compute the supervised loss if not already provided (e.g., from cache)
     if "errors" not in metrics:
@@ -168,7 +170,8 @@ def eval_density(
 
 
 def eval(
-    model: Estimator,
+    estimator: Estimator,
+    *,
     trainable_state: EstimatorTrainableState,
     create_state_fn: CompiledCreateStateFn,
     compute_estimate_fn: CompiledComputeEstimateFn,
@@ -179,11 +182,11 @@ def eval(
     time_sample: float | None = None,
     time_enriching: float | None = None,
 ) -> Metrics:
-    """Evaluate the model on a SynthpixBatch.
+    """Evaluate the estimator on a SynthpixBatch.
 
     Args:
-        model: The model to evaluate.
-        trainable_state: The trained state of the model.
+        estimator: The estimator to evaluate.
+        trainable_state: The trained state of the estimator.
         create_state_fn: Function to create the state.
         compute_estimate_fn: Function to compute the estimate.
         batch: A batch of images and flow fields.
@@ -200,7 +203,7 @@ def eval(
         key = jax.random.PRNGKey(0)
     if estimate_type == "flow":
         metrics = eval_flow(
-            model=model,
+            estimator=estimator,
             trained_state=trainable_state,
             create_state_fn=create_state_fn,
             compute_flow_fn=compute_estimate_fn,
@@ -210,7 +213,7 @@ def eval(
         )
     else:
         metrics = eval_density(
-            model=model,
+            estimator=estimator,
             trained_state=trainable_state,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,
@@ -240,7 +243,8 @@ def eval(
 
 
 def evaluate_batches(
-    model: Estimator,
+    estimator: Estimator,
+    *,
     sampler: Sampler,
     create_state_fn: CompiledCreateStateFn,
     compute_estimate_fn: CompiledComputeEstimateFn,
@@ -255,7 +259,7 @@ def evaluate_batches(
     metrics.
 
     Args:
-        model: Estimator to evaluate.
+        estimator: Estimator to evaluate.
         sampler: Data sampler producing SynthpixBatch items.
         create_state_fn: Function that initializes estimator state.
         compute_estimate_fn: Function that computes estimates.
@@ -293,13 +297,13 @@ def evaluate_batches(
 
         cache_payload = enrich_batch(
             batch,
-            model,
+            estimator,
             cache_manager=cache_manager,
             trainable_state=trainable_state,
         )
 
         metrics = eval(
-            model=model,
+            estimator=estimator,
             trainable_state=trainable_state,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,
@@ -380,14 +384,15 @@ def evaluate_batches(
         summary[f"{metric_name}/max"] = jnp.nanmax(arr)
         summary[f"{metric_name}/min"] = jnp.nanmin(arr)
 
-    # Allow model to add derived metrics to the summary
-    processed = model.process_metrics(dict(summary))
+    # Allow estimator to add derived metrics to the summary
+    processed = estimator.process_metrics(dict(summary))
     summary.update(processed)
     return Metrics(summary)
 
 
 def eval_full_dataset(
-    model: Estimator,
+    estimator: Estimator,
+    *,
     sampler: Sampler,
     create_state_fn: CompiledCreateStateFn,
     compute_estimate_fn: CompiledComputeEstimateFn,
@@ -398,14 +403,14 @@ def eval_full_dataset(
     num_batches: int | None = None,
     cache_manager: CacheManager | None = None,
 ) -> None:
-    """Run the full evaluation of the model.
+    """Run the full evaluation of the estimator.
 
     Args:
-        model: The model to evaluate.
+        estimator: The estimator to evaluate.
         sampler: The image sampler for evaluation.
         create_state_fn: Function to create the state.
         compute_estimate_fn: Function to compute the estimate.
-        trainable_state: The trained state of the model.
+        trainable_state: The trained state of the estimator.
         estimate_type: Type of the estimator ("flow" or "density").
         key: Random key for JAX operations.
             Defaults to jax.random.PRNGKey(0).
@@ -460,7 +465,7 @@ def eval_full_dataset(
             t_enrich_start = time.time()
             cache_payload = enrich_batch(
                 batch,
-                model,
+                estimator,
                 cache_manager=cache_manager,
                 trainable_state=trainable_state,
             )
@@ -469,7 +474,7 @@ def eval_full_dataset(
 
             t_evaluate_start = time.time()
             metrics = eval(
-                model=model,
+                estimator=estimator,
                 trainable_state=trainable_state,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
@@ -607,7 +612,7 @@ def eval_full_dataset(
             )
 
         # Push finalized metrics to logger
-        logger.push(model.finalize_metrics(), step=batches_processed)
+        logger.push(estimator.finalize_metrics(), step=batches_processed)
 
         wall_time = time.time() - t_start
         logger.info(

--- a/src/flowgym/common/base/estimator.py
+++ b/src/flowgym/common/base/estimator.py
@@ -493,7 +493,7 @@ class Estimator(abc.ABC):
 
         Args:
             experience: The experience to prepare.
-            trainable_state: Current trainable state of the model.
+            trainable_state: Current trainable state of the estimator.
 
         Returns:
             The prepared experience (may be the same or enriched).
@@ -516,7 +516,7 @@ class Estimator(abc.ABC):
 
         Rules for Meta-Estimators:
             Meta-estimators can override this to aggregate cached data from
-            their sub-model caches, returning a combined payload
+            their sub-estimator caches, returning a combined payload
             (e.g., `"epe_all"`, `"epe_mask"`).
 
         Args:
@@ -545,7 +545,7 @@ class Estimator(abc.ABC):
         This method provides a unified interface for cache preloading. The
         default implementation is a no-op.
 
-        Meta-estimators can override this to load their sub-model caches
+        Meta-estimators can override this to load their sub-estimator caches
         into memory at startup for fast aggregation during training.
 
         Args:
@@ -559,17 +559,17 @@ class Estimator(abc.ABC):
         self,
         trainable_state: EstimatorTrainableState | None,
     ) -> str:
-        """Get a suffix for the cache ID based on the model state.
+        """Get a suffix for the cache ID based on the estimator state.
 
         This allows the cache to be invalidated or namespaced based on the
-        specific weights or configuration of the model. The returned string
+        specific weights or configuration of the estimator. The returned string
         is appended to the base class name to form a unique `cache_id`.
 
         Standard practice is to hash the `trainable_state.params` and the
         estimator's internal configuration.
 
         Args:
-            trainable_state: The current trainable state, or None if the model
+            trainable_state: The current trainable state, or None if the estimator
                 is not trainable or parameters are not yet initialized.
 
         Returns:

--- a/src/flowgym/common/base/estimator.py
+++ b/src/flowgym/common/base/estimator.py
@@ -516,7 +516,7 @@ class Estimator(abc.ABC):
 
         Rules for Meta-Estimators:
             Meta-estimators can override this to aggregate cached data from
-            their sub-estimator caches, returning a combined payload
+            their component estimator caches, returning a combined payload
             (e.g., `"epe_all"`, `"epe_mask"`).
 
         Args:
@@ -545,8 +545,8 @@ class Estimator(abc.ABC):
         This method provides a unified interface for cache preloading. The
         default implementation is a no-op.
 
-        Meta-estimators can override this to load their sub-estimator caches
-        into memory at startup for fast aggregation during training.
+        Meta-estimators can override this to load their component estimator
+        caches into memory at startup for fast aggregation during training.
 
         Args:
             root_dir: Root directory containing cache files.

--- a/src/flowgym/common/base/trainable_state.py
+++ b/src/flowgym/common/base/trainable_state.py
@@ -21,14 +21,14 @@ class EstimatorTrainableState:
     """Base class for trainable states.
 
     - Can be instantiated and carried around as an "empty" state.
-    - Safe to use for non-trainable estimators (e.g. eval-only models).
+    - Safe to use for non-trainable estimators (e.g. eval-only estimators).
     - If you actually try to *train* with this base instance
       (apply_gradients / replace), it will fail loudly.
 
     Attributes:
         step: Current training step.
-        apply_fn: Callable used to compute model outputs.
-        params: Trainable model parameters.
+        apply_fn: Callable used to compute estimator outputs.
+        params: Trainable estimator parameters.
         extras: Additional estimator state.
     """
 

--- a/src/flowgym/environment/fluid_env.py
+++ b/src/flowgym/environment/fluid_env.py
@@ -69,11 +69,10 @@ class FluidEnv:
             state: The current state of the environment (sampler, gt).
 
         Returns:
-            obs: The initial observation (pair of images).
-            state: The next state of the environment.
-            done: An array of booleans indicating if each
-                episode is done. Shape (batch_size,). If episodic is False,
-                this will always be False.
+            A tuple `(obs, state, done)` where `obs` is the initial pair
+            of images, `state` is the next environment state, and `done`
+            contains per-sample episode flags with shape `(batch_size,)`.
+            If episodic mode is disabled, all values in `done` are `False`.
 
         Raises:
             ValueError: If episodic mode is enabled but sampler doesn't

--- a/src/flowgym/environment/fluid_env.py
+++ b/src/flowgym/environment/fluid_env.py
@@ -69,10 +69,11 @@ class FluidEnv:
             state: The current state of the environment (sampler, gt).
 
         Returns:
-            A tuple `(obs, state, done)` where `obs` is the initial pair
-            of images, `state` is the next environment state, and `done`
-            contains per-sample episode flags with shape `(batch_size,)`.
-            If episodic mode is disabled, all values in `done` are `False`.
+            obs: The initial observation (pair of images).
+            state: The next state of the environment.
+            done: An array of booleans indicating if each
+                episode is done. Shape (batch_size,). If episodic is False,
+                this will always be False.
 
         Raises:
             ValueError: If episodic mode is enabled but sampler doesn't

--- a/src/flowgym/flow/base.py
+++ b/src/flowgym/flow/base.py
@@ -93,7 +93,7 @@ class FlowFieldEstimator(Estimator):
             Args:
                 image: The input image.
                 state: The state object containing historical images.
-                trainable_state: Current trainable state of the model.
+                trainable_state: Current trainable state of the estimator.
                 extras: Additional extras dictionary.
 
             Returns:

--- a/src/flowgym/flow/consensus/consensus.py
+++ b/src/flowgym/flow/consensus/consensus.py
@@ -136,7 +136,7 @@ class ConsensusFlowEstimator(FlowFieldEstimator):
             else:
                 subkey = None
             (trainable_state, _, compute_estimate_fn, _) = make_estimator(
-                model_config=cfg,
+                estimator_config=cfg,
                 load_from=cfg.get("load_from"),
                 rng=subkey,
             )

--- a/src/flowgym/flow/dummy.py
+++ b/src/flowgym/flow/dummy.py
@@ -119,7 +119,7 @@ class DummyEstimator(FlowFieldEstimator):
 
         Args:
             experience: The experience to prepare.
-            trainable_state: Current trainable state of the model.
+            trainable_state: Current trainable state of the estimator.
 
         Returns:
             The prepared experience (may have marker added to state).

--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -22,7 +22,7 @@ from flax.core import FrozenDict, freeze
 from goggles import get_logger
 from goggles.history.types import History
 
-# Models
+# Estimators
 from flowgym.common.base import Estimator
 from flowgym.common.base.trainable_state import (
     EstimatorTrainableState,
@@ -59,8 +59,11 @@ def make_manager(ckpt_dir: Path, keep: int = 3) -> ocp.CheckpointManager:
 
 
 @overload
-def compile_model(
-    model: Estimator, estimates: None, jit: bool = True, history_size: int = 1
+def compile_estimator(
+    estimator: Estimator,
+    estimates: None,
+    jit: bool = True,
+    history_size: int = 1,
 ) -> tuple[
     None,
     CompiledComputeEstimateFn,
@@ -68,8 +71,8 @@ def compile_model(
 
 
 @overload
-def compile_model(
-    model: Estimator,
+def compile_estimator(
+    estimator: Estimator,
     estimates: jnp.ndarray,
     jit: bool = True,
     history_size: int = 1,
@@ -79,8 +82,8 @@ def compile_model(
 ]: ...
 
 
-def compile_model(
-    model: Estimator,
+def compile_estimator(
+    estimator: Estimator,
     estimates: jnp.ndarray | None,
     jit: bool = True,
     history_size: int = 1,
@@ -88,13 +91,13 @@ def compile_model(
     CompiledCreateStateFn | None,
     CompiledComputeEstimateFn,
 ]:
-    """Compile the model for JAX.
+    """Compile the estimator for JAX.
 
     Args:
-        model: The flow field estimator model.
+        estimator: The flow field estimator instance.
         estimates: Example estimates for shape inference.
         jit: Whether to use JIT compilation.
-        history_size: The size of the history for the model.
+        history_size: The size of the history for the estimator.
 
     Returns:
         Compiled functions.
@@ -103,7 +106,7 @@ def compile_model(
     if estimates is not None:
 
         def create_state_fn_impl(images: jnp.ndarray, rng: PRNGKey) -> History:
-            return model.create_state(
+            return estimator.create_state(
                 images,
                 estimates=estimates,
                 image_history_size=history_size,
@@ -121,7 +124,7 @@ def compile_model(
         trainable_state: EstimatorTrainableState,
         cache_payload: CachePayload | None = None,
     ) -> tuple[History, dict]:
-        return model(
+        return estimator(
             images, state, trainable_state, cache_payload=cache_payload
         )
 
@@ -219,7 +222,7 @@ def save_estimator(
     return str(ckpt_root / str(step))
 
 
-def load_model(
+def load_estimator(
     ckpt_dir: str | Path,
     template_state: NNEstimatorTrainableState,
     mode: Literal["resume", "params_only"] = "params_only",
@@ -450,17 +453,17 @@ def make_estimator(
         estimator_config: Configuration dictionary for the estimator.
         image_shape: Shape of the input images (B, H, W).
         estimate_shape: Shape of the estimate. Defaults to (B, H, W, 2).
-        load_from: Path to load the trained model state.
+        load_from: Path to load the trained estimator state.
         rng: Random number generator key or seed.
 
     Returns:
-        EstimatorTrainableState: The trainable state of the model.
-        callable: Function to create the model state.
-        callable: Function to compute the model estimate.
-        Estimator: The model instance.
+        EstimatorTrainableState: The trainable state of the estimator.
+        callable: Function to create the estimator state.
+        callable: Function to compute the estimator estimate.
+        Estimator: The estimator instance.
 
     Raises:
-        ValueError: If estimator not found or model loading fails.
+        ValueError: If estimator not found or estimator loading fails.
     """
     # Import here to avoid circular dependency
     from flowgym import ALL_ESTIMATORS as ESTIMATORS  # noqa: PLC0415
@@ -470,14 +473,14 @@ def make_estimator(
         raise ValueError(
             f"Estimator {estimator_config['estimator']} not found."
         )
-    model_class = ESTIMATORS.get(estimator_config["estimator"])
-    if model_class is None:
+    estimator_class = ESTIMATORS.get(estimator_config["estimator"])
+    if estimator_class is None:
         raise ValueError(
             f"Estimator {estimator_config['estimator']} not found."
         )
-    elif isinstance(model_class, MissingDependency):
-        model_class()  # Raises MissingDependency error
-        # Type narrowing: model_class is not MissingDependency here
+    elif isinstance(estimator_class, MissingDependency):
+        estimator_class()  # Raises MissingDependency error
+        # Type narrowing: estimator_class is not MissingDependency here
         raise ValueError("Unreachable")  # pragma: no cover
 
     if rng is None:
@@ -485,8 +488,8 @@ def make_estimator(
     elif isinstance(rng, int):
         rng = jax.random.PRNGKey(rng)
 
-    # Create the model instance
-    model = cast(type[Estimator], model_class).from_config(
+    # Create the estimator instance
+    estimator = cast(type[Estimator], estimator_class).from_config(
         estimator_config["config"]
         | {
             "estimate_shape": estimate_shape,
@@ -500,22 +503,24 @@ def make_estimator(
     if load_from:
         if estimator_config["estimator"] == "raft_torch":
             if torch is None:
-                raise ValueError("torch required for raft_torch model")
+                raise ValueError("torch required for raft_torch estimator")
             checkpoint = torch.load(load_from, map_location="cuda")
-            model_any = model  # type: Any
-            model_any.raft.load_state_dict(
+            estimator_any = estimator  # type: Any
+            estimator_any.raft.load_state_dict(
                 checkpoint["model_state_dict"], strict=False
             )
             trained_state = None
         else:
             mode = estimator_config.get("load_mode", "params_only")
-            template_state = model.create_trainable_state(
+            template_state = estimator.create_trainable_state(
                 jnp.zeros(image_shape, dtype=jnp.float32), key=rng
             )
             if isinstance(template_state, NNEstimatorTrainableState):
-                trained_state = load_model(load_from, template_state, mode=mode)
+                trained_state = load_estimator(
+                    load_from, template_state, mode=mode
+                )
             else:
-                raise ValueError("Model is not a neural network estimator.")
+                raise ValueError("Estimator is not a neural network estimator.")
         logger.info("Trainable state loaded successfully.")
     # Create a dummy input to initialize the trainable state
     elif image_shape is None:
@@ -525,7 +530,7 @@ def make_estimator(
         trained_state = None
     else:
         sample_images = jnp.zeros(image_shape, dtype=jnp.float32)
-        trained_state = model.create_trainable_state(sample_images, key=rng)
+        trained_state = estimator.create_trainable_state(sample_images, key=rng)
         logger.info("Trainable state created successfully.")
 
     if estimate_shape is None:
@@ -542,15 +547,15 @@ def make_estimator(
         dummy_estimates = None
     else:
         dummy_estimates = jnp.zeros(estimate_shape, dtype=jnp.float32)
-    create_state_fn, compute_estimate_fn = compile_model(
-        model,
+    create_state_fn, compute_estimate_fn = compile_estimator(
+        estimator,
         dummy_estimates,
         estimator_config["config"].get("jit", False) and not DEBUG,
         history_size=estimator_config["config"].get("history_size", 1),
     )
     logger.info("Estimator compiled successfully.")
 
-    return trained_state, create_state_fn, compute_estimate_fn, model
+    return trained_state, create_state_fn, compute_estimate_fn, estimator
 
 
 def select_gt(estimate_type: str, batch: SynthpixBatch) -> jnp.ndarray:

--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -1,4 +1,4 @@
-"""Module for compiling, saving, and loading flow field estimator models."""
+"""Module for compiling, saving, and loading flow field estimators."""
 
 from __future__ import annotations
 
@@ -132,28 +132,33 @@ def compile_model(
     return create_state_fn, compute_estimate_fn
 
 
-def save_model(
+def save_estimator(
     state: NNEstimatorTrainableState,
     out_dir: str | Path,
     step: int | None = None,
-    model: Estimator | None = None,
-    model_name: str | None = None,
+    estimator: Estimator | None = None,
+    estimator_name: str | None = None,
     sampler: Any | None = None,
     keep: int = 3,
+    *,
+    model: Estimator | None = None,
+    model_name: str | None = None,
 ) -> str:
     """Save a training checkpoint using Orbax.
 
-    Checkpoint saved to out_dir/checkpoints/<model_name>/step_<step>.
+    Checkpoint saved to out_dir/checkpoints/<estimator_name>/step_<step>.
 
     Args:
         state: The trainable state to save (PyTree).
         out_dir: Root output directory for this experiment/run.
         step: Training step/batch index. If None, reads from `state.step`.
-        model: The model instance (to extract optimizer_config).
-        model_name: Optional model name for directory nesting.
+        estimator: The estimator instance (to extract optimizer_config).
+        estimator_name: Optional estimator name for directory nesting.
         sampler: The sampler instance to save (must be Sampler with
             Grain scheduler for full state saving).
         keep: Number of checkpoints to keep.
+        model: Backward-compatible alias for `estimator`.
+        model_name: Backward-compatible alias for `estimator_name`.
 
     Returns:
         The saved step directory path.
@@ -161,6 +166,18 @@ def save_model(
     Raises:
         ValueError: If step is not provided and state has no 'step' attr.
     """
+    if estimator is not None and model is not None:
+        raise TypeError("Pass only one of 'estimator' or 'model'.")
+    if estimator_name is not None and model_name is not None:
+        raise TypeError(
+            "Pass only one of 'estimator_name' or 'model_name'."
+        )
+
+    if estimator is None:
+        estimator = model
+    if estimator_name is None:
+        estimator_name = model_name
+
     out_dir = Path(out_dir)
     out_dir = out_dir.resolve()
 
@@ -172,10 +189,10 @@ def save_model(
             raise ValueError("step not provided and state has no 'step' attr")
     step = int(step)
 
-    # Nesting: out_dir/checkpoints/<model_name>/step_<step>
+    # Nesting: out_dir/checkpoints/<estimator_name>/step_<step>
     parts = [out_dir, "checkpoints"]
-    if model_name is not None:
-        parts.append(model_name)
+    if estimator_name is not None:
+        parts.append(estimator_name)
 
     ckpt_root = Path(*parts)
     ckpt_root.mkdir(parents=True, exist_ok=True)
@@ -194,9 +211,9 @@ def save_model(
     }
 
     # Extract and save optimizer config separately (as it contains strings)
-    if model is not None:
+    if estimator is not None:
         opt_cfg = getattr(
-            model, "optimizer_config", getattr(model, "opt_config", None)
+            estimator, "optimizer_config", getattr(estimator, "opt_config", None)
         )
         if opt_cfg is not None:
             save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # type: ignore
@@ -217,6 +234,27 @@ def save_model(
         mngr.wait_until_finished()
 
     return str(ckpt_root / str(step))
+
+
+def save_model(
+    state: NNEstimatorTrainableState,
+    out_dir: str | Path,
+    step: int | None = None,
+    model: Estimator | None = None,
+    model_name: str | None = None,
+    sampler: Any | None = None,
+    keep: int = 3,
+) -> str:
+    """Backward-compatible wrapper for `save_estimator`."""
+    return save_estimator(
+        state=state,
+        out_dir=out_dir,
+        step=step,
+        estimator=model,
+        estimator_name=model_name,
+        sampler=sampler,
+        keep=keep,
+    )
 
 
 def load_model(
@@ -382,7 +420,7 @@ def load_model(
 
 @overload
 def make_estimator(
-    model_config: dict,
+    estimator_config: dict,
     image_shape: tuple,
     estimate_shape: tuple,
     load_from: str | None = None,
@@ -397,7 +435,7 @@ def make_estimator(
 
 @overload
 def make_estimator(
-    model_config: dict,
+    estimator_config: dict,
     image_shape: tuple,
     estimate_shape: None,
     load_from: str | None = None,
@@ -412,7 +450,7 @@ def make_estimator(
 
 @overload
 def make_estimator(
-    model_config: dict,
+    estimator_config: dict,
     image_shape: tuple | None = None,
     estimate_shape: tuple | None = None,
     load_from: str | None = None,
@@ -426,11 +464,13 @@ def make_estimator(
 
 
 def make_estimator(
-    model_config: dict,
+    estimator_config: dict | None = None,
     image_shape: tuple | None = None,
     estimate_shape: tuple | None = None,
     load_from: str | None = None,
     rng: PRNGKey | int | None = None,
+    *,
+    model_config: dict | None = None,
 ) -> tuple[
     EstimatorTrainableState | None,
     CompiledCreateStateFn | None,
@@ -441,17 +481,18 @@ def make_estimator(
 
     If load_from is not provided, a new trainable state is created.
 
-    model_config keys:
+    estimator_config keys:
     - estimator: Name of the estimator.
     - estimator_type: Type of the estimator ("flow" or "density").
     - config: Configuration dictionary for the estimator.
 
     Args:
-        model_config: Configuration dictionary for the estimator.
+        estimator_config: Configuration dictionary for the estimator.
         image_shape: Shape of the input images (B, H, W).
         estimate_shape: Shape of the estimate. Defaults to (B, H, W, 2).
         load_from: Path to load the trained model state.
         rng: Random number generator key or seed.
+        model_config: Backward-compatible alias for `estimator_config`.
 
     Returns:
         EstimatorTrainableState: The trainable state of the model.
@@ -462,15 +503,28 @@ def make_estimator(
     Raises:
         ValueError: If estimator not found or model loading fails.
     """
+    if estimator_config is not None and model_config is not None:
+        raise TypeError(
+            "Pass only one of 'estimator_config' or 'model_config'."
+        )
+    if estimator_config is None:
+        estimator_config = model_config
+    if estimator_config is None:
+        raise TypeError("Missing required config: 'estimator_config'.")
+
     # Import here to avoid circular dependency
     from flowgym import ALL_ESTIMATORS as ESTIMATORS  # noqa: PLC0415
 
     # Extract the estimator class from the config
-    if model_config["estimator"] not in ESTIMATORS:
-        raise ValueError(f"Estimator {model_config['estimator']} not found.")
-    model_class = ESTIMATORS.get(model_config["estimator"])
+    if estimator_config["estimator"] not in ESTIMATORS:
+        raise ValueError(
+            f"Estimator {estimator_config['estimator']} not found."
+        )
+    model_class = ESTIMATORS.get(estimator_config["estimator"])
     if model_class is None:
-        raise ValueError(f"Estimator {model_config['estimator']} not found.")
+        raise ValueError(
+            f"Estimator {estimator_config['estimator']} not found."
+        )
     elif isinstance(model_class, MissingDependency):
         model_class()  # Raises MissingDependency error
         # Type narrowing: model_class is not MissingDependency here
@@ -483,18 +537,18 @@ def make_estimator(
 
     # Create the model instance
     model = cast(type[Estimator], model_class).from_config(
-        model_config["config"]
+        estimator_config["config"]
         | {
             "estimate_shape": estimate_shape,
             "image_shape": image_shape,
             "rng": rng,
         }
     )
-    logger.info("Model created successfully.")
+    logger.info("Estimator created successfully.")
 
     # Load or create the trainable state
     if load_from:
-        if model_config["estimator"] == "raft_torch":
+        if estimator_config["estimator"] == "raft_torch":
             if torch is None:
                 raise ValueError("torch required for raft_torch model")
             checkpoint = torch.load(load_from, map_location="cuda")
@@ -504,7 +558,7 @@ def make_estimator(
             )
             trained_state = None
         else:
-            mode = model_config.get("load_mode", "params_only")
+            mode = estimator_config.get("load_mode", "params_only")
             template_state = model.create_trainable_state(
                 jnp.zeros(image_shape, dtype=jnp.float32), key=rng
             )
@@ -541,10 +595,10 @@ def make_estimator(
     create_state_fn, compute_estimate_fn = compile_model(
         model,
         dummy_estimates,
-        model_config["config"].get("jit", False) and not DEBUG,
-        history_size=model_config["config"].get("history_size", 1),
+        estimator_config["config"].get("jit", False) and not DEBUG,
+        history_size=estimator_config["config"].get("history_size", 1),
     )
-    logger.info("Model compiled successfully.")
+    logger.info("Estimator compiled successfully.")
 
     return trained_state, create_state_fn, compute_estimate_fn, model
 

--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -146,7 +146,7 @@ def save_estimator(
 ) -> str:
     """Save a training checkpoint using Orbax.
 
-    Checkpoint saved to out_dir/checkpoints/<estimator_name>/step_<step>.
+    Checkpoint saved to out_dir/checkpoints/<estimator_name>/<step>.
 
     Args:
         state: The trainable state to save (PyTree).
@@ -175,7 +175,7 @@ def save_estimator(
             raise ValueError("step not provided and state has no 'step' attr")
     step = int(step)
 
-    # Nesting: out_dir/checkpoints/<estimator_name>/step_<step>
+    # Nesting: out_dir/checkpoints/<estimator_name>/<step>
     parts = [out_dir, "checkpoints"]
     if estimator_name is not None:
         parts.append(estimator_name)

--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -140,9 +140,6 @@ def save_estimator(
     estimator_name: str | None = None,
     sampler: Any | None = None,
     keep: int = 3,
-    *,
-    model: Estimator | None = None,
-    model_name: str | None = None,
 ) -> str:
     """Save a training checkpoint using Orbax.
 
@@ -157,8 +154,6 @@ def save_estimator(
         sampler: The sampler instance to save (must be Sampler with
             Grain scheduler for full state saving).
         keep: Number of checkpoints to keep.
-        model: Backward-compatible alias for `estimator`.
-        model_name: Backward-compatible alias for `estimator_name`.
 
     Returns:
         The saved step directory path.
@@ -166,18 +161,6 @@ def save_estimator(
     Raises:
         ValueError: If step is not provided and state has no 'step' attr.
     """
-    if estimator is not None and model is not None:
-        raise TypeError("Pass only one of 'estimator' or 'model'.")
-    if estimator_name is not None and model_name is not None:
-        raise TypeError(
-            "Pass only one of 'estimator_name' or 'model_name'."
-        )
-
-    if estimator is None:
-        estimator = model
-    if estimator_name is None:
-        estimator_name = model_name
-
     out_dir = Path(out_dir)
     out_dir = out_dir.resolve()
 
@@ -234,27 +217,6 @@ def save_estimator(
         mngr.wait_until_finished()
 
     return str(ckpt_root / str(step))
-
-
-def save_model(
-    state: NNEstimatorTrainableState,
-    out_dir: str | Path,
-    step: int | None = None,
-    model: Estimator | None = None,
-    model_name: str | None = None,
-    sampler: Any | None = None,
-    keep: int = 3,
-) -> str:
-    """Backward-compatible wrapper for `save_estimator`."""
-    return save_estimator(
-        state=state,
-        out_dir=out_dir,
-        step=step,
-        estimator=model,
-        estimator_name=model_name,
-        sampler=sampler,
-        keep=keep,
-    )
 
 
 def load_model(
@@ -464,13 +426,11 @@ def make_estimator(
 
 
 def make_estimator(
-    estimator_config: dict | None = None,
+    estimator_config: dict,
     image_shape: tuple | None = None,
     estimate_shape: tuple | None = None,
     load_from: str | None = None,
     rng: PRNGKey | int | None = None,
-    *,
-    model_config: dict | None = None,
 ) -> tuple[
     EstimatorTrainableState | None,
     CompiledCreateStateFn | None,
@@ -492,7 +452,6 @@ def make_estimator(
         estimate_shape: Shape of the estimate. Defaults to (B, H, W, 2).
         load_from: Path to load the trained model state.
         rng: Random number generator key or seed.
-        model_config: Backward-compatible alias for `estimator_config`.
 
     Returns:
         EstimatorTrainableState: The trainable state of the model.
@@ -503,15 +462,6 @@ def make_estimator(
     Raises:
         ValueError: If estimator not found or model loading fails.
     """
-    if estimator_config is not None and model_config is not None:
-        raise TypeError(
-            "Pass only one of 'estimator_config' or 'model_config'."
-        )
-    if estimator_config is None:
-        estimator_config = model_config
-    if estimator_config is None:
-        raise TypeError("Missing required config: 'estimator_config'.")
-
     # Import here to avoid circular dependency
     from flowgym import ALL_ESTIMATORS as ESTIMATORS  # noqa: PLC0415
 

--- a/src/flowgym/training/caching.py
+++ b/src/flowgym/training/caching.py
@@ -584,7 +584,7 @@ def enrich_batch(
         except Exception as e:
             logger.error(f"Error in estimator.enrich: {e}")
             logger.error(f"miss_idxs: {miss_idxs_absolute}")
-            raise e
+            raise
 
         if payload_miss is not None:
             # Merge into valid payload

--- a/src/flowgym/training/caching.py
+++ b/src/flowgym/training/caching.py
@@ -1,4 +1,4 @@
-"""Caching layer for derived batch data (e.g., model estimates, metrics)."""
+"""Caching layer for derived batch data (e.g., estimator outputs, metrics)."""
 
 from __future__ import annotations
 
@@ -523,7 +523,7 @@ class CacheManager:
 
 def enrich_batch(
     batch: SynthpixBatch,
-    model: Estimator,
+    estimator: Estimator,
     *,
     cache_manager: CacheManager | None = None,
     trainable_state: EstimatorTrainableState | None = None,
@@ -532,7 +532,7 @@ def enrich_batch(
 
     This function orchestrates the read-through cache flow:
     1. Lookup cached entries via CacheManager
-    2. Call model.enrich() for missing entries
+    2. Call estimator.enrich() for missing entries
     3. Write newly computed entries to cache
     4. Return complete payload
 
@@ -540,15 +540,15 @@ def enrich_batch(
 
     Args:
         batch: The batch to enrich.
-        model: The estimator to use for enrichment.
+        estimator: The estimator to use for enrichment.
         cache_manager: Optional CacheManager for storage.
-        trainable_state: Current trainable state (passed to model.enrich).
+        trainable_state: Current trainable state (passed to estimator.enrich).
 
     Returns:
         A CachePayload with enriched data.
 
     Raises:
-        Exception: If model.enrich() or cache_manager.write() raise.
+        Exception: If estimator.enrich() or cache_manager.write() raise.
     """
     if cache_manager is None:
         return CachePayload()
@@ -576,13 +576,13 @@ def enrich_batch(
         miss_idxs_relative = np.where(~hit)[0]
         miss_idxs_absolute = valid_indices[miss_idxs_relative]
 
-        # Call model.enrich for missing entries
+        # Call estimator.enrich for missing entries
         try:
-            payload_miss = model.enrich(
+            payload_miss = estimator.enrich(
                 batch, miss_idxs_absolute, trainable_state=trainable_state
             )
         except Exception as e:
-            logger.error(f"Error in model.enrich: {e}")
+            logger.error(f"Error in estimator.enrich: {e}")
             logger.error(f"miss_idxs: {miss_idxs_absolute}")
             raise e
 
@@ -620,22 +620,22 @@ def enrich_batch(
 
 
 def build_cache_id(
-    model: Estimator,
+    estimator: Estimator,
     trainable_state: Any,
     caching_config: dict,
 ) -> str:
-    """Build a cache ID from model, state, and config.
+    """Build a cache ID from estimator, state, and config.
 
     Args:
-        model: The estimator to build cache ID for.
+        estimator: The estimator to build cache ID for.
         trainable_state: Current trainable state (for suffix generation).
         caching_config: Caching configuration dict (contains base cache_id).
 
     Returns:
         The constructed cache ID string.
     """
-    suffix = model.get_cache_id_suffix(trainable_state)
+    suffix = estimator.get_cache_id_suffix(trainable_state)
     if "cache_id" in caching_config:
         base = caching_config["cache_id"]
         return f"{base}{suffix}" if suffix else base
-    return f"{model.__class__.__name__}{suffix}"
+    return f"{estimator.__class__.__name__}{suffix}"

--- a/src/flowgym/training/optimizer.py
+++ b/src/flowgym/training/optimizer.py
@@ -50,6 +50,21 @@ def build_optimizer_from_config(
 ) -> optax.GradientTransformation:
     """Build a GradientTransformation from a config mapping.
 
+    Config format example:
+        name: "adam"
+        hyperparams:
+            learning_rate:
+                schedule:
+                    name: "exponential_decay"
+                    ...  # schedule kwargs
+            b1: 0.9
+            b2: 0.999
+        chain:
+            - name: "clip_by_global_norm"
+            kwargs: {max_norm: 1.0}
+            - name: "add_decayed_weights"
+            kwargs: {weight_decay: 1.0e-4}
+
     Args:
         config: Configuration dictionary for the optimizer.
 
@@ -58,32 +73,6 @@ def build_optimizer_from_config(
 
     Raises:
         ValueError: If config is invalid or optimizer name is unknown.
-
-    Example:
-        Example optimizer config::
-
-            {
-                "name": "adam",
-                "hyperparams": {
-                    "learning_rate": {
-                        "schedule": {
-                            "name": "exponential_decay",
-                        },
-                    },
-                    "b1": 0.9,
-                    "b2": 0.999,
-                },
-                "chain": [
-                    {
-                        "name": "clip_by_global_norm",
-                        "kwargs": {"max_norm": 1.0},
-                    },
-                    {
-                        "name": "add_decayed_weights",
-                        "kwargs": {"weight_decay": 1.0e-4},
-                    },
-                ],
-            }
     """
     cfg = config.copy()
     if "name" not in cfg:

--- a/src/flowgym/training/optimizer.py
+++ b/src/flowgym/training/optimizer.py
@@ -50,21 +50,6 @@ def build_optimizer_from_config(
 ) -> optax.GradientTransformation:
     """Build a GradientTransformation from a config mapping.
 
-    Config format example:
-        name: "adam"
-        hyperparams:
-            learning_rate:
-                schedule:
-                    name: "exponential_decay"
-                    ...  # schedule kwargs
-            b1: 0.9
-            b2: 0.999
-        chain:
-            - name: "clip_by_global_norm"
-            kwargs: {max_norm: 1.0}
-            - name: "add_decayed_weights"
-            kwargs: {weight_decay: 1.0e-4}
-
     Args:
         config: Configuration dictionary for the optimizer.
 
@@ -73,6 +58,32 @@ def build_optimizer_from_config(
 
     Raises:
         ValueError: If config is invalid or optimizer name is unknown.
+
+    Example:
+        Example optimizer config::
+
+            {
+                "name": "adam",
+                "hyperparams": {
+                    "learning_rate": {
+                        "schedule": {
+                            "name": "exponential_decay",
+                        },
+                    },
+                    "b1": 0.9,
+                    "b2": 0.999,
+                },
+                "chain": [
+                    {
+                        "name": "clip_by_global_norm",
+                        "kwargs": {"max_norm": 1.0},
+                    },
+                    {
+                        "name": "add_decayed_weights",
+                        "kwargs": {"weight_decay": 1.0e-4},
+                    },
+                ],
+            }
     """
     cfg = config.copy()
     if "name" not in cfg:

--- a/src/flowgym/types.py
+++ b/src/flowgym/types.py
@@ -43,7 +43,7 @@ class CachePayload:
         has_precomputed_errors: Whether per-sample EPE data is available.
         epe: Per-sample EPE (B,) for regular estimators.
         relative_epe: Relative EPE (B,) for regular estimators.
-        epe_all: Per-sub-estimator EPE (B, K) for meta-estimators.
+        epe_all: Per-component-estimator EPE (B, K) for meta-estimators.
         epe_mask: Validity mask (B, K) aligned with epe_all.
         estimates: Pre-computed flow estimates (B, ...).
         extras: Opaque estimator-specific data (e.g., candidate flows for

--- a/src/flowgym/types.py
+++ b/src/flowgym/types.py
@@ -43,7 +43,7 @@ class CachePayload:
         has_precomputed_errors: Whether per-sample EPE data is available.
         epe: Per-sample EPE (B,) for regular estimators.
         relative_epe: Relative EPE (B,) for regular estimators.
-        epe_all: Per-sub-model EPE (B, K) for meta-estimators (ArtOfPIV).
+        epe_all: Per-sub-estimator EPE (B, K) for meta-estimators.
         epe_mask: Validity mask (B, K) aligned with epe_all.
         estimates: Pre-computed flow estimates (B, ...).
         extras: Opaque estimator-specific data (e.g., candidate flows for
@@ -272,8 +272,8 @@ class CompiledCreateStateFn(Protocol):
     """Protocol for the compiled state creation function.
 
     NOTE: This protocol is for the create-state callable returned by
-    `make_estimator`/`compile_model`, not `Estimator.create_state`.
-    `compile_model` binds `estimates` and history sizes ahead of time.
+    `make_estimator`/`compile_estimator`, not `Estimator.create_state`.
+    `compile_estimator` binds `estimates` and history sizes ahead of time.
     """
 
     def __call__(
@@ -308,7 +308,7 @@ class CompiledComputeEstimateFn(Protocol):
         Args:
             images: Input images.
             state: Current estimator state.
-            trainable_state: Trainable model state.
+            trainable_state: Trainable estimator state.
             cache_payload: Optional precomputed data.
 
         Returns:

--- a/src/main.py
+++ b/src/main.py
@@ -57,10 +57,10 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--model",
+        "--estimator",
         type=str,
         required=True,
-        help="Configuration of the model to use.",
+        help="Configuration of the estimator to use.",
     )
 
     parser.add_argument(
@@ -100,8 +100,8 @@ def prepare_configs(
     validation_settings = None
     caching_config = None
 
-    # Load the model
-    model_config = load_configuration(args.model)
+    # Load the estimator
+    estimator_config = load_configuration(args.estimator)
 
     # output directory
     out_dir = None
@@ -193,10 +193,10 @@ def prepare_configs(
             caching_config["spec"] = parsed_spec
 
     if args.mode in {"train", "train-supervised"}:
-        # Prepare the output directory to save the model
-        out_dir = model_config.get("out_dir", "output")
+        # Prepare the output directory to save the estimator
+        out_dir = estimator_config.get("out_dir", "output")
         out_dir = os.path.join(
-            out_dir, model_config["estimator"], str(dataset_config["seed"])
+            out_dir, estimator_config["estimator"], str(dataset_config["seed"])
         )
         os.makedirs(out_dir, exist_ok=True)
     elif args.mode == "compare-samplers":
@@ -206,23 +206,23 @@ def prepare_configs(
         dataset_config2["loop"] = False
         dataset_config2["randomize"] = False
 
-    log_model_config = {**model_config}
-    log_model_config["config"] = {**model_config["config"]}
-    for k, v in log_model_config["config"].items():
+    log_estimator_config = {**estimator_config}
+    log_estimator_config["config"] = {**estimator_config["config"]}
+    for k, v in log_estimator_config["config"].items():
         if isinstance(v, str) and v.endswith(".yaml"):
-            log_model_config["config"][k] = load_configuration(v)
+            log_estimator_config["config"][k] = load_configuration(v)
 
-    if model_config.get("run_name", None) is None:
-        model_config["run_name"] = (
-            f"{args.mode}_{model_config['estimator']}_{args.dataset.split('/')[-1].split('.')[0]}"
+    if estimator_config.get("run_name", None) is None:
+        estimator_config["run_name"] = (
+            f"{args.mode}_{estimator_config['estimator']}_{args.dataset.split('/')[-1].split('.')[0]}"
         )
 
     gg.attach(
         gg.WandBHandler(
             project="Art_of_PIV",
-            run_name=model_config["run_name"],
+            run_name=estimator_config["run_name"],
             config={
-                "model_config": log_model_config,
+                "estimator_config": log_estimator_config,
                 "dataset_config": dataset_config,
                 "dataset_config2": dataset_config2,
                 "validation": validation_settings,
@@ -235,7 +235,7 @@ def prepare_configs(
     return (
         dataset_config,
         dataset_config2,
-        model_config,
+        estimator_config,
         out_dir,
         validation_settings,
         caching_config,
@@ -249,7 +249,7 @@ if __name__ == "__main__":
     (
         dataset_config,
         dataset_config_to_compare,
-        model_config,
+        estimator_config,
         out_dir,
         validation_settings,
         caching_config,
@@ -264,8 +264,8 @@ if __name__ == "__main__":
             step=0,
         )
         logger.artifact(  # pyright: ignore[reportAttributeAccessIssue]
-            data=model_config,
-            name="model_config",
+            data=estimator_config,
+            name="estimator_config",
             format="yaml",
             step=0,
         )
@@ -312,7 +312,7 @@ if __name__ == "__main__":
             raise  # Re-raise the exception after shutdown
 
         gt = select_gt(
-            model_config["estimate_type"],
+            estimator_config["estimate_type"],
             batch,
         )
     else:
@@ -347,7 +347,7 @@ if __name__ == "__main__":
             sampler.shutdown()
             gg.finish()
 
-    estimate_shape = model_config.get("estimate_shape", None)
+    estimate_shape = estimator_config.get("estimate_shape", None)
     if estimate_shape is not None:
         estimate_shape = (batch.images1.shape[0], *tuple(estimate_shape))
     else:
@@ -356,13 +356,13 @@ if __name__ == "__main__":
     # Create the estimator
     (trainable_state, create_state_fn, compute_estimate_fn, model) = (
         make_estimator(
-            model_config,
+            estimator_config,
             image_shape=(
                 batch.images1.shape[0],
                 *dataset_config["image_shape"],
             ),
             estimate_shape=estimate_shape,
-            load_from=model_config.get("load_from", None),
+            load_from=estimator_config.get("load_from", None),
             rng=subkey,
         )
     )
@@ -409,7 +409,7 @@ if __name__ == "__main__":
 
         try:
             eval_full_dataset(
-                model=model,
+                estimator=model,
                 sampler=sampler,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
@@ -446,8 +446,8 @@ if __name__ == "__main__":
 
         try:
             train(
-                model=model,
-                model_config=model_config,
+                estimator=model,
+                estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
                 create_state_fn=create_state_fn,
@@ -459,16 +459,16 @@ if __name__ == "__main__":
                 log_every=dataset_config.get("log_every", 100),
                 obs=obs,
                 key=key,
-                replay_buffer_capacity=model_config["config"]
+                replay_buffer_capacity=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get(
                     "capacity",
                     dataset_config.get("replay_buffer_capacity", 10000),
                 ),
-                replay_ratio=model_config["config"]
+                replay_ratio=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get("replay_ratio", dataset_config.get("replay_ratio", 0.0)),
-                prefetch_replay_size=model_config["config"]
+                prefetch_replay_size=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get(
                     "prefetch_replay_size",
@@ -524,8 +524,8 @@ if __name__ == "__main__":
 
         try:
             train_supervised(
-                model=model,
-                model_config=model_config,
+                estimator=model,
+                estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
                 create_state_fn=create_state_fn,
@@ -535,21 +535,21 @@ if __name__ == "__main__":
                 val_interval=val_interval,
                 val_num_batches=val_num_batches,
                 num_batches=dataset_config.get("num_batches", 1000),
-                estimate_type=model_config["estimate_type"],
+                estimate_type=estimator_config["estimate_type"],
                 save_every=dataset_config.get("save_every", 100),
                 log_every=dataset_config.get("log_every", 1),
                 save_only_best=dataset_config.get("save_only_best", False),
                 key=key,
-                replay_buffer_capacity=model_config["config"]
+                replay_buffer_capacity=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get(
                     "capacity",
                     dataset_config.get("replay_buffer_capacity", 0),
                 ),
-                replay_ratio=model_config["config"]
+                replay_ratio=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get("replay_ratio", dataset_config.get("replay_ratio", 0.0)),
-                prefetch_replay_size=model_config["config"]
+                prefetch_replay_size=estimator_config["config"]
                 .get("replay_buffer_config", {})
                 .get(
                     "prefetch_replay_size",
@@ -606,7 +606,7 @@ if __name__ == "__main__":
             batch2 = next(sampler2)
             assert trainable_state is not None
             comparison(
-                model_config=model_config,
+                model_config=estimator_config,
                 sampler1=sampler,
                 sampler2=sampler2,
                 model=model,

--- a/src/main.py
+++ b/src/main.py
@@ -76,7 +76,7 @@ def parse_args():
 def prepare_configs(
     args: argparse.Namespace,
 ) -> tuple[dict, dict | None, dict, str | None, dict | None, dict | None]:
-    """Prepare dataset and model configurations based on command line arguments.
+    """Prepare dataset and estimator configurations based on command line arguments.
 
     Args:
         args: Parsed command line arguments.
@@ -86,7 +86,7 @@ def prepare_configs(
             - Dataset configuration dictionary.
             - Second dataset configuration dictionary for comparison,
                 if in compare mode.
-            - Model configuration dictionary.
+            - Estimator configuration dictionary.
             - Output directory path if in training mode, else None.
             - Validation settings dictionary, if validation is enabled.
             - Caching configuration dictionary, if caching is enabled.
@@ -289,7 +289,7 @@ if __name__ == "__main__":
             "Configuration artifacts will not be logged."
         )
     if out_dir is not None:
-        logger.info(f"Saving models in directory: {out_dir}")
+        logger.info(f"Saving estimators in directory: {out_dir}")
 
     key = jax.random.PRNGKey(dataset_config["seed"])
     key, subkey = jax.random.split(key)
@@ -354,7 +354,7 @@ if __name__ == "__main__":
         estimate_shape = gt.shape
 
     # Create the estimator
-    (trainable_state, create_state_fn, compute_estimate_fn, model) = (
+    (trainable_state, create_state_fn, compute_estimate_fn, estimator) = (
         make_estimator(
             estimator_config,
             image_shape=(
@@ -395,21 +395,21 @@ if __name__ == "__main__":
                 "Initializing CacheManager from dataset config: "
                 f"{caching_config}"
             )
-            # Append model-specific suffix to cache_id (e.g. hash of weights)
+            # Append estimator-specific suffix to cache_id (e.g. hash of weights)
             if "cache_id" in caching_config:
-                suffix = model.get_cache_id_suffix(trainable_state)
+                suffix = estimator.get_cache_id_suffix(trainable_state)
                 if suffix:
                     caching_config["cache_id"] += suffix
                     cache_id = caching_config["cache_id"]
                     logger.info(
-                        f"Updated cache_id with model suffix: {cache_id}"
+                        f"Updated cache_id with estimator suffix: {cache_id}"
                     )
 
             cache_manager = CacheManager(**caching_config)
 
         try:
             eval_full_dataset(
-                estimator=model,
+                estimator=estimator,
                 sampler=sampler,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
@@ -446,7 +446,7 @@ if __name__ == "__main__":
 
         try:
             train(
-                estimator=model,
+                estimator=estimator,
                 estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
@@ -502,7 +502,7 @@ if __name__ == "__main__":
                 "NNEstimatorTrainableState."
             )
 
-        logger.info("Training supervised model...")
+        logger.info("Training supervised estimator...")
 
         # Caching Setup
         cache_manager = None
@@ -511,20 +511,20 @@ if __name__ == "__main__":
                 "Initializing CacheManager from dataset config: "
                 f"{caching_config}"
             )
-            # Append model-specific suffix to cache_id (e.g. hash of weights)
+            # Append estimator-specific suffix to cache_id (e.g. hash of weights)
             if "cache_id" in caching_config:
-                suffix = model.get_cache_id_suffix(trainable_state)
+                suffix = estimator.get_cache_id_suffix(trainable_state)
                 if suffix:
                     caching_config["cache_id"] += suffix
                     cache_id = caching_config["cache_id"]
                     logger.info(
-                        f"Updated cache_id with model suffix: {cache_id}"
+                        f"Updated cache_id with estimator suffix: {cache_id}"
                     )
             cache_manager = CacheManager(**caching_config)
 
         try:
             train_supervised(
-                estimator=model,
+                estimator=estimator,
                 estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
@@ -573,7 +573,7 @@ if __name__ == "__main__":
                 if i != 0:
                     batch = next(sampler)
                 eval(
-                    model=model,
+                    estimator=estimator,
                     trainable_state=trainable_state,
                     create_state_fn=create_state_fn,
                     compute_estimate_fn=compute_estimate_fn,
@@ -606,10 +606,10 @@ if __name__ == "__main__":
             batch2 = next(sampler2)
             assert trainable_state is not None
             comparison(
-                model_config=estimator_config,
+                estimator_config=estimator_config,
                 sampler1=sampler,
                 sampler2=sampler2,
-                model=model,
+                estimator=estimator,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
                 trainable_state=trainable_state,

--- a/src/main.py
+++ b/src/main.py
@@ -414,7 +414,7 @@ if __name__ == "__main__":
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
                 trainable_state=trainable_state,
-                estimate_type=model_config["estimate_type"],
+                estimate_type=estimator_config["estimate_type"],
                 key=key,
                 print_files=dataset_config.get("print_files", False),
                 num_batches=dataset_config.get("num_batches", None),

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from goggles import Metrics
 
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
 from flowgym.environment.fluid_env import EnvState, FluidEnv, Observation
-from flowgym.make import save_model
+from flowgym.make import save_estimator
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
     CompiledComputeEstimateFn,
@@ -22,6 +22,9 @@ from flowgym.types import (
 from flowgym.utils import DEBUG, GracefulShutdown, log_flow_estimate
 
 logger = gg.get_logger(__name__, with_metrics=True)
+
+# Keep the old module attribute available for tests and external patching.
+save_model = save_estimator
 
 
 def train(
@@ -254,11 +257,11 @@ def train(
                 logger.info(f"Episode {episode_idx} - {k}: {avg_value}")
 
             if episode_idx % save_every == 0:
-                save_model(
+                save_estimator(
                     state=trainable_state,
                     out_dir=out_dir,
-                    model=model,
-                    model_name=f"{model.__class__.__name__}-{episode_idx}",
+                    estimator=model,
+                    estimator_name=f"{model.__class__.__name__}-{episode_idx}",
                     sampler=env_state[0],
                 )
 

--- a/src/train.py
+++ b/src/train.py
@@ -23,9 +23,6 @@ from flowgym.utils import DEBUG, GracefulShutdown, log_flow_estimate
 
 logger = gg.get_logger(__name__, with_metrics=True)
 
-# Keep the old module attribute available for tests and external patching.
-save_model = save_estimator
-
 
 def train(
     model: Estimator,

--- a/src/train.py
+++ b/src/train.py
@@ -25,8 +25,9 @@ logger = gg.get_logger(__name__, with_metrics=True)
 
 
 def train(
-    model: Estimator,
-    model_config: dict,
+    estimator: Estimator,
+    estimator_config: dict,
+    *,
     trainable_state: NNEstimatorTrainableState,
     out_dir: str,
     create_state_fn: CompiledCreateStateFn,
@@ -45,16 +46,16 @@ def train(
     """Train the flow estimator.
 
     Args:
-        model: The flow estimator model.
-        model_config: Configuration for the model.
-        trainable_state: The initial state of the model.
-        out_dir: Directory to save the model.
+        estimator: The flow estimator.
+        estimator_config: Configuration for the estimator.
+        trainable_state: The initial state of the estimator.
+        out_dir: Directory to save the estimator.
         create_state_fn: Function to create the initial state of the estimator.
         compute_estimate_fn: Function to compute the flow estimate.
         env: The environment to train in.
         env_state: Initial state of the environment.
         num_episodes: Number of episodes to train for.
-        save_every: Frequency to save the model.
+        save_every: Frequency to save the estimator.
         log_every: Frequency to log the training progress.
         obs: Initial observations from the environment.
         key: Random key for JAX operations.
@@ -64,15 +65,15 @@ def train(
             enables GPU prefetch.
     """
     # Create the training step function
-    train_step_fn = model.create_train_step()
+    train_step_fn = estimator.create_train_step()
     assert isinstance(train_step_fn, RLTrainStep), (
         f"Expected RLTrainStep callable, got {type(train_step_fn)}"
     )
 
-    if model_config["config"].get("jit", False) and not DEBUG:
+    if estimator_config["config"].get("jit", False) and not DEBUG:
         train_step_fn = jax.jit(train_step_fn)
 
-    logger.info("Model compiled successfully.")
+    logger.info("Estimator compiled successfully.")
 
     # Handle randomization key
     key, subkey = jax.random.split(key)
@@ -117,7 +118,7 @@ def train(
                 t_reset = time.time() - t_reset
                 logger.info(f"Environment reset took {t_reset} seconds.")
 
-                # Reset the state of the model and propagate the key
+                # Reset the state of the estimator and propagate the key
                 key, subkey = jax.random.split(key)
                 estimation_state = create_state_fn(obs[0], subkey)
 
@@ -136,7 +137,7 @@ def train(
                 t = time.time() - t
 
                 # Post process, log and append the metrics
-                metrics = model.process_metrics(metrics)
+                metrics = estimator.process_metrics(metrics)
                 logger.push(metrics, step=episode_idx)
 
                 # Extract the action (the last estimate)
@@ -234,7 +235,7 @@ def train(
                 metrics["step_time"] = t
                 episode_metrics.append(metrics)
 
-                # Update the state of the model
+                # Update the state of the estimator
                 if len(estimation_state["images"][0]) > 1:
                     estimation_state["images"] = (
                         estimation_state["images"]
@@ -257,8 +258,8 @@ def train(
                 save_estimator(
                     state=trainable_state,
                     out_dir=out_dir,
-                    estimator=model,
-                    estimator_name=f"{model.__class__.__name__}-{episode_idx}",
+                    estimator=estimator,
+                    estimator_name=f"{estimator.__class__.__name__}-{episode_idx}",
                     sampler=env_state[0],
                 )
 

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -26,9 +26,6 @@ from flowgym.utils import DEBUG, GracefulShutdown
 
 logger = gg.get_logger(__name__, with_metrics=True)
 
-# Keep the old module attribute available for tests and external patching.
-save_model = save_estimator
-
 
 def train_supervised(
     model: Estimator,

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -12,7 +12,7 @@ from synthpix.sampler import Sampler
 
 from eval import evaluate_batches
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
-from flowgym.make import save_model
+from flowgym.make import save_estimator
 from flowgym.training.caching import CacheManager, enrich_batch
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
@@ -25,6 +25,9 @@ from flowgym.types import (
 from flowgym.utils import DEBUG, GracefulShutdown
 
 logger = gg.get_logger(__name__, with_metrics=True)
+
+# Keep the old module attribute available for tests and external patching.
+save_model = save_estimator
 
 
 def train_supervised(
@@ -388,12 +391,12 @@ def train_supervised(
                     batch_idx % save_every == 0 or batch_idx == num_batches - 1
                 ):
                     if not save_only_best:
-                        save_model(
+                        save_estimator(
                             state=trainable_state,
                             out_dir=out_dir,
                             step=batch_idx,
-                            model=model,
-                            model_name=model.__class__.__name__,
+                            estimator=model,
+                            estimator_name=model.__class__.__name__,
                             sampler=sampler,
                         )
 
@@ -411,12 +414,12 @@ def train_supervised(
                         if current_mean_error < best_mean_error:
                             best_mean_error = current_mean_error
 
-                            save_model(
+                            save_estimator(
                                 state=trainable_state,
                                 out_dir=out_dir,
                                 step=batch_idx,
-                                model=model,
-                                model_name=model.__class__.__name__,
+                                estimator=model,
+                                estimator_name=model.__class__.__name__,
                                 sampler=sampler,
                             )
 

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -28,8 +28,9 @@ logger = gg.get_logger(__name__, with_metrics=True)
 
 
 def train_supervised(
-    model: Estimator,
-    model_config: dict,
+    estimator: Estimator,
+    estimator_config: dict,
+    *,
     trainable_state: NNEstimatorTrainableState,
     out_dir: str,
     create_state_fn: CompiledCreateStateFn,
@@ -52,21 +53,21 @@ def train_supervised(
     """Train the flow estimator.
 
     Args:
-        model: The flow estimator model.
-        model_config: Configuration for the model.
-        trainable_state: The initial state of the model.
-        out_dir: Directory to save the model.
+        estimator: The flow estimator.
+        estimator_config: Configuration for the estimator.
+        trainable_state: The initial state of the estimator.
+        out_dir: Directory to save the estimator.
         create_state_fn: Function to create the initial state of the estimator.
         compute_estimate_fn: Function to compute the estimate.
         sampler: The sampler to use to generate images.
         val_sampler: The sampler to use to generate images for validation.
-        val_interval: Frequency to validate the model.
+        val_interval: Frequency to validate the estimator.
         val_num_batches: Number of batches to validate for.
         num_batches: Number of batches to train for.
         estimate_type: Type of estimate to compute.
-        save_every: Frequency to save the model.
+        save_every: Frequency to save the estimator.
         log_every: Frequency to log the training progress.
-        save_only_best: Whether to save only the best model
+        save_only_best: Whether to save only the best estimator
                     by evaluating it on the validation set.
         key: Random key for JAX operations.
         replay_buffer_capacity: Capacity of the replay buffer.
@@ -84,12 +85,12 @@ def train_supervised(
         key = jax.random.PRNGKey(0)
 
     # Create the training step function
-    train_step_fn = model.create_train_step()
+    train_step_fn = estimator.create_train_step()
     assert isinstance(train_step_fn, SupervisedTrainStep), (
         "Expected SupervisedTrainStep callable"
     )
 
-    if model_config["config"].get("jit", False) and not DEBUG:
+    if estimator_config["config"].get("jit", False) and not DEBUG:
         train_step_fn = jax.jit(train_step_fn)
 
     logger.info("Training step function compiled successfully.")
@@ -128,7 +129,7 @@ def train_supervised(
             key, val_key = jax.random.split(key)
             try:
                 val_metrics = evaluate_batches(
-                    model=model,
+                    estimator=estimator,
                     sampler=val_sampler,
                     create_state_fn=create_state_fn,
                     compute_estimate_fn=compute_estimate_fn,
@@ -207,7 +208,7 @@ def train_supervised(
                 t_enrich = time.time()
                 cache_payload = enrich_batch(
                     batch,
-                    model,
+                    estimator,
                     cache_manager=cache_manager,
                     trainable_state=trainable_state,
                 )
@@ -252,8 +253,8 @@ def train_supervised(
 
                 # Store experience in the replay buffer
                 if replay_buffer is not None:
-                    # Allow model to enrich experience before storing
-                    enriched_experience = model.prepare_experience_for_replay(
+                    # Allow estimator to enrich experience before storing
+                    enriched_experience = estimator.prepare_experience_for_replay(
                         experience, trainable_state
                     )
                     # We store unbatched experiences
@@ -320,7 +321,7 @@ def train_supervised(
 
                     try:
                         val_metrics = evaluate_batches(
-                            model=model,
+                            estimator=estimator,
                             sampler=val_sampler,
                             create_state_fn=create_state_fn,
                             compute_estimate_fn=compute_estimate_fn,
@@ -392,14 +393,14 @@ def train_supervised(
                             state=trainable_state,
                             out_dir=out_dir,
                             step=batch_idx,
-                            estimator=model,
-                            estimator_name=model.__class__.__name__,
+                            estimator=estimator,
+                            estimator_name=estimator.__class__.__name__,
                             sampler=sampler,
                         )
 
                     elif last_val_metrics is None:
                         logger.info(
-                            f"Skipping best-model save at batch {batch_idx}: "
+                            f"Skipping best-estimator save at batch {batch_idx}: "
                             f"no validation computed yet."
                         )
                     else:
@@ -415,13 +416,13 @@ def train_supervised(
                                 state=trainable_state,
                                 out_dir=out_dir,
                                 step=batch_idx,
-                                estimator=model,
-                                estimator_name=model.__class__.__name__,
+                                estimator=estimator,
+                                estimator_name=estimator.__class__.__name__,
                                 sampler=sampler,
                             )
 
                             logger.info(
-                                f"New best model saved at batch {batch_idx} "
+                                f"New best estimator saved at batch {batch_idx} "
                                 f"(mean_error={current_mean_error:.6f})"
                             )
 
@@ -442,7 +443,7 @@ def train_supervised(
             key, val_key = jax.random.split(key)
             try:
                 final_val_metrics = evaluate_batches(
-                    model=model,
+                    estimator=estimator,
                     sampler=val_sampler,
                     create_state_fn=create_state_fn,
                     compute_estimate_fn=compute_estimate_fn,

--- a/tests/caching/flow/test_dis_cache.py
+++ b/tests/caching/flow/test_dis_cache.py
@@ -42,8 +42,8 @@ def test_cache_manager_spec_storage(cache_dir):
 
 def test_dis_get_config():
     """Test get_config method of DIS estimator."""
-    model = DISJAXFlowFieldEstimator(preset=PresetType.FAST)
-    config = model.get_config()
+    estimator = DISJAXFlowFieldEstimator(preset=PresetType.FAST)
+    config = estimator.get_config()
 
     assert config["preset"] == "FAST"
     assert config["patch_size"] == 9
@@ -53,8 +53,8 @@ def test_dis_get_config():
 
 def test_dis_enrich(tmp_path):
     """Test enrich returns correct EPE payload."""
-    # Setup model
-    model = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
+    # Setup estimator
+    estimator = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
 
     # Create fake batch
     B, H, W = 2, 32, 32
@@ -80,7 +80,7 @@ def test_dis_enrich(tmp_path):
     miss_idxs = jnp.array([0, 1])
 
     # Run enrich
-    payload = model.enrich(batch, miss_idxs)
+    payload = estimator.enrich(batch, miss_idxs)
 
     assert payload is not None
     assert payload["epe"] is not None
@@ -89,15 +89,15 @@ def test_dis_enrich(tmp_path):
 
     # Check partial miss
     miss_idxs_partial = jnp.array([0])
-    payload_partial = model.enrich(batch, miss_idxs_partial)
+    payload_partial = estimator.enrich(batch, miss_idxs_partial)
     assert payload_partial is not None
     assert payload_partial["epe"].shape == (1,)
 
 
 def test_integration_enrich(cache_dir):
-    """Test full enrich flow with CacheManager and DIS model."""
+    """Test full enrich flow with CacheManager and DIS estimator."""
     spec = {"epe": (np.dtype("float32"), ())}
-    model = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
+    estimator = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
 
     cm = CacheManager(
         root_dir=str(cache_dir),
@@ -120,7 +120,7 @@ def test_integration_enrich(cache_dir):
     )
 
     # 1. Enrich (should be miss -> compute -> write)
-    payload = enrich_batch(batch, model, cache_manager=cm)
+    payload = enrich_batch(batch, estimator, cache_manager=cm)
     assert payload is not None
     assert payload.epe is not None
     assert payload.epe.shape == (B,)
@@ -144,7 +144,7 @@ def test_integration_enrich(cache_dir):
 
 def test_dis_uses_cached_metrics_without_running_flow(monkeypatch):
     """DIS should short-circuit when cache provides precomputed metrics."""
-    model = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
+    estimator = DISJAXFlowFieldEstimator(preset=PresetType.ULTRAFAST)
 
     B, H, W = 2, 32, 32
     key = jax.random.PRNGKey(7)
@@ -153,10 +153,10 @@ def test_dis_uses_cached_metrics_without_running_flow(monkeypatch):
     images2 = jax.random.uniform(k2, (B, H, W))
 
     init_flow = jnp.zeros((B, H, W, 2), dtype=jnp.float32)
-    state = model.create_state(
+    state = estimator.create_state(
         images1, init_flow, image_history_size=2, rng=key
     )
-    trainable_state = model.create_trainable_state(images1, key)
+    trainable_state = estimator.create_trainable_state(images1, key)
 
     cache_payload = CachePayload(
         has_precomputed_errors=True,
@@ -174,7 +174,7 @@ def test_dis_uses_cached_metrics_without_running_flow(monkeypatch):
         fail_if_called,
     )
 
-    new_state, metrics = model(
+    new_state, metrics = estimator(
         images2,
         state,
         trainable_state,

--- a/tests/caching/flow/test_estimator_cache.py
+++ b/tests/caching/flow/test_estimator_cache.py
@@ -104,7 +104,7 @@ class TestCacheManagerEnrich:
     """Test CacheManager.enrich integration with estimators."""
 
     def test_enrich_computes_misses(self, mock_cache_dir, mock_synthpix_batch):
-        """Test that enrich_batch calls model.enrich for misses."""
+        """Test that enrich_batch calls estimator.enrich for misses."""
         from unittest.mock import MagicMock
 
         from flowgym.training.caching import enrich_batch
@@ -116,25 +116,25 @@ class TestCacheManagerEnrich:
             spec=spec,
         )
 
-        # Mock model
-        model = MagicMock()
+        # Mock estimator
+        estimator = MagicMock()
         B = mock_synthpix_batch.images1.shape[0]
 
         def compute_miss(batch, miss_idxs, **kwargs):
             return {"epe": np.ones(len(miss_idxs), dtype=np.float32) * 0.5}
 
-        model.enrich.side_effect = compute_miss
+        estimator.enrich.side_effect = compute_miss
 
         # First call - all misses
-        payload = enrich_batch(mock_synthpix_batch, model, cache_manager=cm)
+        payload = enrich_batch(mock_synthpix_batch, estimator, cache_manager=cm)
         assert payload is not None
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
         np.testing.assert_allclose(payload.epe, np.ones(B) * 0.5)
 
         # Second call - all hits
-        model.enrich.reset_mock()
-        payload2 = enrich_batch(mock_synthpix_batch, model, cache_manager=cm)
-        assert model.enrich.call_count == 0  # No misses
+        estimator.enrich.reset_mock()
+        payload2 = enrich_batch(mock_synthpix_batch, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 0  # No misses
         np.testing.assert_allclose(payload2.epe, np.ones(B) * 0.5)
 
     def test_enrich_mixed_hits_misses(self, mock_cache_dir):
@@ -169,16 +169,16 @@ class TestCacheManagerEnrich:
             ),  # 100 is cached, 200 is not
         )
 
-        model = MagicMock()
+        estimator = MagicMock()
 
         def compute_miss(batch, miss_idxs, **kwargs):
             # Only the second sample (index 1) should be a miss
             return {"epe": np.array([0.2], dtype=np.float32)}
 
-        model.enrich.side_effect = compute_miss
+        estimator.enrich.side_effect = compute_miss
 
-        payload = enrich_batch(batch, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        payload = enrich_batch(batch, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Check merged result
         np.testing.assert_allclose(payload.epe[0], 0.1)  # From cache

--- a/tests/caching/flow/test_raft_cache.py
+++ b/tests/caching/flow/test_raft_cache.py
@@ -129,7 +129,7 @@ class TestRaftCacheIntegration:
 
     @pytest.mark.run_explicitly
     def test_raft_enrich_cycle(self, mock_cache_dir):
-        """Test full enrich cycle with RAFT model."""
+        """Test full enrich cycle with RAFT Estimator."""
         from flowgym.flow.raft.raft_jax import RaftJaxEstimator
 
         estimator = RaftJaxEstimator(

--- a/tests/caching/flow/test_raft_cache.py
+++ b/tests/caching/flow/test_raft_cache.py
@@ -129,7 +129,7 @@ class TestRaftCacheIntegration:
 
     @pytest.mark.run_explicitly
     def test_raft_enrich_cycle(self, mock_cache_dir):
-        """Test full enrich cycle with RAFT Estimator."""
+        """Test full enrich cycle with RAFT estimator."""
         from flowgym.flow.raft.raft_jax import RaftJaxEstimator
 
         estimator = RaftJaxEstimator(

--- a/tests/caching/test_cache_key_generation.py
+++ b/tests/caching/test_cache_key_generation.py
@@ -44,14 +44,14 @@ class TestCacheKeyGenerationForRealImages:
             files=["path/to/image_001.mat", "path/to/image_002.mat"]
         )
 
-        model = MagicMock()
-        model.enrich.return_value = {
+        estimator = MagicMock()
+        estimator.enrich.return_value = {
             "epe": np.array([0.1, 0.2], dtype=np.float32)
         }
 
         # First enrich call
-        payload1 = enrich_batch(batch, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        payload1 = enrich_batch(batch, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Same filenames, different random keys (simulating different epoch)
         batch2 = SynthpixBatch(
@@ -65,11 +65,11 @@ class TestCacheKeyGenerationForRealImages:
         )
 
         # Reset mock and call again
-        model.enrich.reset_mock()
-        payload2 = enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        payload2 = enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache hit - same filenames means same cache keys
-        assert model.enrich.call_count == 0
+        assert estimator.enrich.call_count == 0
         np.testing.assert_allclose(payload1.epe, payload2.epe)
 
     def test_real_image_key_ignores_path_prefix(self, mock_cache_dir):
@@ -89,12 +89,12 @@ class TestCacheKeyGenerationForRealImages:
         )
         batch1 = batch1.update(files=["/absolute/path/to/test_file.mat"])
 
-        model = MagicMock()
-        model.enrich.return_value = {"epe": np.array([0.5], dtype=np.float32)}
+        estimator = MagicMock()
+        estimator.enrich.return_value = {"epe": np.array([0.5], dtype=np.float32)}
 
         # First enrich
-        enrich_batch(batch1, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        enrich_batch(batch1, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Same filename but different path prefix
         batch2 = SynthpixBatch(
@@ -107,11 +107,11 @@ class TestCacheKeyGenerationForRealImages:
             files=["different/dir/test_file.mat"]
         )  # Same basename
 
-        model.enrich.reset_mock()
-        enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache hit - same basename = same cache key
-        assert model.enrich.call_count == 0
+        assert estimator.enrich.call_count == 0
 
     def test_different_filenames_produce_different_keys(self, mock_cache_dir):
         """Test that different filenames produce different cache keys."""
@@ -130,11 +130,11 @@ class TestCacheKeyGenerationForRealImages:
         )
         batch1 = batch1.update(files=["file_A.mat"])
 
-        model = MagicMock()
-        model.enrich.return_value = {"epe": np.array([0.5], dtype=np.float32)}
+        estimator = MagicMock()
+        estimator.enrich.return_value = {"epe": np.array([0.5], dtype=np.float32)}
 
-        enrich_batch(batch1, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        enrich_batch(batch1, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Different filename
         batch2 = SynthpixBatch(
@@ -145,11 +145,11 @@ class TestCacheKeyGenerationForRealImages:
         )
         batch2 = batch2.update(files=["file_B.mat"])  # Different filename
 
-        model.enrich.reset_mock()
-        enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache miss - different filename = different cache key
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
 
 class TestCacheKeyGenerationForSyntheticImages:
@@ -176,13 +176,13 @@ class TestCacheKeyGenerationForSyntheticImages:
         # Add params to signal synthetic batch
         batch1 = batch1.update(params={"some": "generation_params"})
 
-        model = MagicMock()
-        model.enrich.return_value = {
+        estimator = MagicMock()
+        estimator.enrich.return_value = {
             "epe": np.array([0.1, 0.2], dtype=np.float32)
         }
 
-        enrich_batch(batch1, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        enrich_batch(batch1, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Same keys should hit cache
         batch2 = SynthpixBatch(
@@ -193,11 +193,11 @@ class TestCacheKeyGenerationForSyntheticImages:
         )
         batch2 = batch2.update(params={"different": "params"})
 
-        model.enrich.reset_mock()
-        enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should hit cache - same keys
-        assert model.enrich.call_count == 0
+        assert estimator.enrich.call_count == 0
 
     def test_synthetic_different_keys_produce_miss(self, mock_cache_dir):
         """Test that different batch.keys produce cache misses."""
@@ -216,13 +216,13 @@ class TestCacheKeyGenerationForSyntheticImages:
         )
         batch1 = batch1.update(params={"gen": "params"})
 
-        model = MagicMock()
-        model.enrich.return_value = {
+        estimator = MagicMock()
+        estimator.enrich.return_value = {
             "epe": np.array([0.1, 0.2], dtype=np.float32)
         }
 
-        enrich_batch(batch1, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        enrich_batch(batch1, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Different keys
         batch2 = SynthpixBatch(
@@ -233,11 +233,11 @@ class TestCacheKeyGenerationForSyntheticImages:
         )
         batch2 = batch2.update(params={"gen": "params"})
 
-        model.enrich.reset_mock()
-        enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache miss - different keys
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
 
 class TestBatchTypeDetection:
@@ -264,30 +264,30 @@ class TestBatchTypeDetection:
         )
         batch = batch.update(files=[f"some/path/{filename}"])
 
-        model = MagicMock()
+        estimator = MagicMock()
         captured_miss_idxs = []
 
         def capture_call(b, miss_idxs, **kwargs):
             captured_miss_idxs.append(miss_idxs)
             return {"epe": np.array([0.1], dtype=np.float32)}
 
-        model.enrich.side_effect = capture_call
-        enrich_batch(batch, model, cache_manager=cm)
+        estimator.enrich.side_effect = capture_call
+        enrich_batch(batch, estimator, cache_manager=cm)
 
         # Verify the internal key assignment happened
         # The key used should be based on the hash, not the original batch.keys
         # We verify by checking if the same filename produces same result
-        model.enrich.reset_mock()
+        estimator.enrich.reset_mock()
         batch2 = batch.update(
             keys=jnp.array([99999], dtype=jnp.uint32)
         )  # Different key
         batch2 = batch2.update(
             files=[f"different/path/{filename}"]
         )  # Same basename
-        enrich_batch(batch2, model, cache_manager=cm)
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache hit because same filename
-        assert model.enrich.call_count == 0
+        assert estimator.enrich.call_count == 0
 
     def test_files_with_params_uses_batch_keys(self, mock_cache_dir):
         """Test batch with files AND params uses batch.keys, not filenames."""
@@ -312,11 +312,11 @@ class TestBatchTypeDetection:
             },  # Having params means synthetic
         )
 
-        model = MagicMock()
-        model.enrich.return_value = {"epe": np.array([0.1], dtype=np.float32)}
+        estimator = MagicMock()
+        estimator.enrich.return_value = {"epe": np.array([0.1], dtype=np.float32)}
 
-        enrich_batch(batch, model, cache_manager=cm)
-        assert model.enrich.call_count == 1
+        enrich_batch(batch, estimator, cache_manager=cm)
+        assert estimator.enrich.call_count == 1
 
         # Same filename but different key - should miss
         batch2 = SynthpixBatch(
@@ -330,11 +330,11 @@ class TestBatchTypeDetection:
             params={"generation": "parameters"},
         )
 
-        model.enrich.reset_mock()
-        enrich_batch(batch2, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        enrich_batch(batch2, estimator, cache_manager=cm)
 
         # Should be cache miss - params present means we use batch.keys
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
 
 if __name__ == "__main__":

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -263,13 +263,13 @@ def test_cache_manager_enrich():
             tmp_dir, cache_id, spec={"values": (np.float32, (2,))}
         )
 
-        # Mock batch and model
+        # Mock batch and estimator
         class MockBatch:
             def __init__(self, keys):
                 self.keys = keys
 
         batch = MockBatch(np.array([1, 2], dtype=np.uint64))
-        model = MagicMock()
+        estimator = MagicMock()
 
         # Define enrich behavior
         # miss_idxs will be [0, 1] for the first call
@@ -280,24 +280,24 @@ def test_cache_manager_enrich():
                 ]
             }
 
-        model.enrich.side_effect = enrich_fn
+        estimator.enrich.side_effect = enrich_fn
 
         # 1. First call (all misses)
-        payload = enrich_batch(batch, model, cache_manager=cm)
+        payload = enrich_batch(batch, estimator, cache_manager=cm)
         assert payload is not None
         np.testing.assert_allclose(
             payload.extras["values"], [[0.1, 0.1], [0.2, 0.2]]
         )
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
         # 2. Second call (all hits)
-        model.enrich.reset_mock()
-        payload2 = enrich_batch(batch, model, cache_manager=cm)
+        estimator.enrich.reset_mock()
+        payload2 = enrich_batch(batch, estimator, cache_manager=cm)
         assert payload2 is not None
         np.testing.assert_allclose(
             payload2.extras["values"], [[0.1, 0.1], [0.2, 0.2]]
         )
-        assert model.enrich.call_count == 0
+        assert estimator.enrich.call_count == 0
 
         # 3. Mixed hits/misses
         batch_mixed = MockBatch(np.array([1, 3], dtype=np.uint64))
@@ -306,10 +306,10 @@ def test_cache_manager_enrich():
             # Only index 1 in batch_mixed is a miss (key 3)
             return {"values": np.array([[0.3, 0.3]], dtype=np.float32)}
 
-        model.enrich.side_effect = enrich_mixed
-        payload3 = enrich_batch(batch_mixed, model, cache_manager=cm)
+        estimator.enrich.side_effect = enrich_mixed
+        payload3 = enrich_batch(batch_mixed, estimator, cache_manager=cm)
         assert payload3 is not None
         np.testing.assert_allclose(
             payload3.extras["values"], [[0.1, 0.1], [0.3, 0.3]]
         )
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1

--- a/tests/caching/test_caching_rules.py
+++ b/tests/caching/test_caching_rules.py
@@ -3,8 +3,8 @@
 This module tests that the caching system follows the standards defined in
 docs/CACHING.md, including:
 - Unique cache ID generation
-- Meta-estimator delegation to sub-model caches
-- Sub-model cache write-back
+- Meta-estimator delegation to sub-estimator caches
+- Sub-estimator cache write-back
 """
 
 
@@ -15,7 +15,7 @@ class TestUniqueCacheIds:
     """Tests for CACHING.md Rule 1: Estimators provide stable, unique IDs."""
 
     def test_different_configs_produce_different_cache_ids(self):
-        """Cache ID should change when model config changes."""
+        """Cache ID should change when estimator config changes."""
 
         # Create two estimators with different configs
         config1 = {
@@ -37,8 +37,8 @@ class TestUniqueCacheIds:
         class MinimalAoP:
             def __init__(self, configs):
                 self.estimator_configs = configs
-                self.sub_models = []
-                self.sub_model_states = []
+                self.sub_estimators = []
+                self.sub_estimator_states = []
 
         est1 = MinimalAoP([{"estimator": "raft", "config": config1}])
         est2 = MinimalAoP([{"estimator": "raft", "config": config2}])
@@ -81,7 +81,7 @@ class TestUniqueCacheIds:
     def test_different_estimator_types_produce_different_cache_ids(self):
         """Different estimator types should have different cache IDs."""
         # This is enforced by class name being part of cache_id
-        # cache_id = f"{model.__class__.__name__}{suffix}"
+        # cache_id = f"{estimator.__class__.__name__}{suffix}"
 
         class EstimatorA:
             pass

--- a/tests/caching/test_caching_rules.py
+++ b/tests/caching/test_caching_rules.py
@@ -3,8 +3,8 @@
 This module tests that the caching system follows the standards defined in
 docs/CACHING.md, including:
 - Unique cache ID generation
-- Meta-estimator delegation to sub-estimator caches
-- Sub-estimator cache write-back
+- Meta-estimator delegation to component estimator caches
+- Component estimator cache write-back
 """
 
 
@@ -37,8 +37,8 @@ class TestUniqueCacheIds:
         class MinimalAoP:
             def __init__(self, configs):
                 self.estimator_configs = configs
-                self.sub_estimators = []
-                self.sub_estimator_states = []
+                self.component_estimators = []
+                self.component_estimator_states = []
 
         est1 = MinimalAoP([{"estimator": "raft", "config": config1}])
         est2 = MinimalAoP([{"estimator": "raft", "config": config2}])

--- a/tests/caching/test_eval_integration.py
+++ b/tests/caching/test_eval_integration.py
@@ -12,17 +12,17 @@ def test_eval_full_dataset_with_caching():
     """Test that eval_full_dataset correctly uses the cache manager."""
 
     # Mock dependencies
-    mock_model = MagicMock(spec=Estimator)
+    mock_estimator = MagicMock(spec=Estimator)
     # Mock default return for process_metrics to avoid iteration errors
-    mock_model.process_metrics.return_value = {"errors": np.array([0.1])}
-    mock_model.finalize_metrics.return_value = {}
-    mock_model.is_oracle.return_value = False
+    mock_estimator.process_metrics.return_value = {"errors": np.array([0.1])}
+    mock_estimator.finalize_metrics.return_value = {}
+    mock_estimator.is_oracle.return_value = False
 
     # Mock enrich to return payload for missing keys
     def enrich_fn(batch, miss_idxs, **kwargs):
         return {"cached_value": np.array([123])}
 
-    mock_model.enrich.side_effect = enrich_fn
+    mock_estimator.enrich.side_effect = enrich_fn
 
     # Create a dummy batch
     batch = SynthpixBatch(
@@ -62,7 +62,7 @@ def test_eval_full_dataset_with_caching():
     # Run eval_full_dataset
     try:
         eval_full_dataset(
-            estimator=mock_model,
+            estimator=mock_estimator,
             sampler=mock_sampler,
             create_state_fn=mock_create_state_fn,
             compute_estimate_fn=mock_compute_estimate_fn,
@@ -84,8 +84,8 @@ def test_eval_full_dataset_with_caching():
     # 2. Verify cache lookup was called
     mock_cache_manager.lookup.assert_called()
 
-    # 3. Verify model.enrich was called for cache misses
-    mock_model.enrich.assert_called()
+    # 3. Verify estimator.enrich was called for cache misses
+    mock_estimator.enrich.assert_called()
 
     # 4. Verify sampler was iterated
     mock_sampler.__iter__.assert_called()

--- a/tests/caching/test_eval_integration.py
+++ b/tests/caching/test_eval_integration.py
@@ -62,7 +62,7 @@ def test_eval_full_dataset_with_caching():
     # Run eval_full_dataset
     try:
         eval_full_dataset(
-            model=mock_model,
+            estimator=mock_model,
             sampler=mock_sampler,
             create_state_fn=mock_create_state_fn,
             compute_estimate_fn=mock_compute_estimate_fn,

--- a/tests/caching/test_eval_integration_v2.py
+++ b/tests/caching/test_eval_integration_v2.py
@@ -65,7 +65,7 @@ def test_evaluate_batches_caching_robust():
             spec={"epe": (np.float32, ())},
         )
 
-        model = MockEvalEstimator()
+        mock_estimator = MockEvalEstimator()
 
         # Batch 1: keys 200, 201
         batch1 = MockEvalBatch(keys=[200, 201])
@@ -82,7 +82,7 @@ def test_evaluate_batches_caching_robust():
 
         # Run evaluate_batches
         results = evaluate_batches(
-            estimator=model,
+            estimator=mock_estimator,
             sampler=sampler,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,
@@ -93,8 +93,8 @@ def test_evaluate_batches_caching_robust():
         )
 
         assert results["mean_error"] == 0.5
-        assert len(model._compute_calls) == 1
-        assert len(model._compute_calls[0]) == 2  # 2 misses
+        assert len(mock_estimator._compute_calls) == 1
+        assert len(mock_estimator._compute_calls[0]) == 2  # 2 misses
 
         # Verify it's now in cache
         _payload, hit = cache_manager.lookup(
@@ -118,7 +118,7 @@ def test_eval_full_dataset_caching_robust():
         )
         cache_manager.flush()
 
-        model = MockEvalEstimator()
+        mock_estimator = MockEvalEstimator()
 
         # Batch: keys 300 (hit), 301 (miss)
         batch = MockEvalBatch(keys=[300, 301])
@@ -146,7 +146,7 @@ def test_eval_full_dataset_caching_robust():
             return state, {"errors": cache_payload.epe}
 
         eval_full_dataset(
-            estimator=model,
+            estimator=mock_estimator,
             sampler=sampler,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,
@@ -155,17 +155,17 @@ def test_eval_full_dataset_caching_robust():
         )
 
         # Check that enrich was called only for 301 (1 sample)
-        assert len(model._compute_calls) == 1
-        assert len(model._compute_calls[0]) == 1  # Only 1 miss (301)
-        assert model._compute_calls[0][0] == 1  # Index 1 in batch
+        assert len(mock_estimator._compute_calls) == 1
+        assert len(mock_estimator._compute_calls[0]) == 1  # Only 1 miss (301)
+        assert mock_estimator._compute_calls[0][0] == 1  # Index 1 in batch
 
         # Verify processed metrics
         # eval() calls process_metrics. The errors passed to eval were
         # [0.1, 0.5].
         # Mean should be 0.3
-        assert len(model._processed_metrics) == 1
+        assert len(mock_estimator._processed_metrics) == 1
         np.testing.assert_allclose(
-            model._processed_metrics[0]["errors"], [0.1, 0.5]
+            mock_estimator._processed_metrics[0]["errors"], [0.1, 0.5]
         )
 
 

--- a/tests/caching/test_eval_integration_v2.py
+++ b/tests/caching/test_eval_integration_v2.py
@@ -82,7 +82,7 @@ def test_evaluate_batches_caching_robust():
 
         # Run evaluate_batches
         results = evaluate_batches(
-            model=model,
+            estimator=model,
             sampler=sampler,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,
@@ -146,7 +146,7 @@ def test_eval_full_dataset_caching_robust():
             return state, {"errors": cache_payload.epe}
 
         eval_full_dataset(
-            model=model,
+            estimator=model,
             sampler=sampler,
             create_state_fn=create_state_fn,
             compute_estimate_fn=compute_estimate_fn,

--- a/tests/caching/test_generic_caching.py
+++ b/tests/caching/test_generic_caching.py
@@ -100,11 +100,11 @@ def test_enrich_generic():
 
         batch = MockBatch(np.array([100], dtype=np.uint64))
 
-        model = MagicMock()
+        estimator = MagicMock()
         # enrich returns correct dict
-        model.enrich.return_value = {"foo": np.array([99.9], dtype=np.float32)}
+        estimator.enrich.return_value = {"foo": np.array([99.9], dtype=np.float32)}
 
-        payload = enrich_batch(batch, model, cache_manager=cm)
+        payload = enrich_batch(batch, estimator, cache_manager=cm)
         assert payload is not None
         assert "foo" in payload.extras
         np.testing.assert_allclose(payload.extras["foo"], [99.9])

--- a/tests/caching/test_integration.py
+++ b/tests/caching/test_integration.py
@@ -44,8 +44,8 @@ def mock_sampler(num_batches, keys_list):
         yield MockBatch(batch_size=len(keys), keys=keys)
 
 
-@patch("src.train_supervised.save_model")
-def test_train_supervised_caching_integration(mock_save_model):
+@patch("src.train_supervised.save_estimator")
+def test_train_supervised_caching_integration(mock_save_estimator):
     """Integration test for caching in train_supervised."""
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -159,8 +159,8 @@ def test_train_supervised_caching_integration(mock_save_model):
         assert payload_5["values"][0, 0] == 5.0
 
 
-@patch("src.train_supervised.save_model")
-def test_estimator_enrich(mock_save_model):
+@patch("src.train_supervised.save_estimator")
+def test_estimator_enrich(mock_save_estimator):
     """Test that Estimator.enrich is called for cache misses."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         cache_manager = CacheManager(

--- a/tests/caching/test_integration.py
+++ b/tests/caching/test_integration.py
@@ -58,8 +58,8 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         )
 
         # 1. Setup Mock Components
-        model = MockEstimator()
-        model_config = {"config": {"jit": False}}
+        estimator = MockEstimator()
+        estimator_config = {"config": {"jit": False}}
         trainable_state = MagicMock(spec=NNEstimatorTrainableState)
         trainable_state.params = {}
         trainable_state.opt_state = {}
@@ -68,15 +68,15 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         create_state_fn = MagicMock(return_value=MagicMock())
         compute_estimate_fn = MagicMock()
 
-        # Define model.enrich to compute payload for missing keys
-        def model_enrich(batch, miss_idxs, **kwargs):
+        # Define estimator.enrich to compute payload for missing keys
+        def estimator_enrich(batch, miss_idxs, **kwargs):
             keys = np.asarray(batch.keys)
             miss_keys = keys[miss_idxs]
             # Payload values: [[key, key], ...] just to verify
             values = np.stack([miss_keys, miss_keys], axis=1).astype(np.float32)
             return {"values": values}
 
-        model.enrich = MagicMock(side_effect=model_enrich)
+        estimator.enrich = MagicMock(side_effect=estimator_enrich)
 
         # 2. Run Training - Pass 1 (All Misses)
         # 2 batches: [1, 2], [3, 4]
@@ -92,8 +92,8 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         sampler_pass1.shutdown = MagicMock()
 
         train_supervised(
-            estimator=model,
-            estimator_config=model_config,
+            estimator=estimator,
+            estimator_config=estimator_config,
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=create_state_fn,
@@ -107,7 +107,7 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         # Verification Pass 1:
         # Check that enrich was called for all 4 items
         # It's called per batch.
-        assert model.enrich.call_count == 2
+        assert estimator.enrich.call_count == 2
 
         # Flush pending writes before verification
         cache_manager.flush()
@@ -131,11 +131,11 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         )
         sampler_pass2.shutdown = MagicMock()
 
-        model.enrich.reset_mock()
+        estimator.enrich.reset_mock()
 
         train_supervised(
-            estimator=model,
-            estimator_config=model_config,
+            estimator=estimator,
+            estimator_config=estimator_config,
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=create_state_fn,
@@ -147,11 +147,11 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         )
 
         # Verification Pass 2:
-        # model.enrich should be called ONCE for the batch
+        # estimator.enrich should be called ONCE for the batch
         # And inside, it receives miss_idxs.
         # But our mock side_effect handles the partial return.
 
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
         # Verify 5 is now in cache
         payload_5, hit_5 = cm_verify.lookup(np.array([5], dtype=np.uint64))
@@ -171,15 +171,15 @@ def test_estimator_enrich(mock_save_estimator):
         )
 
         # Mock Estimator that returns a payload
-        model = MagicMock(spec=MockEstimator)
-        model.create_train_step.return_value = MockTrainStep()
+        estimator = MagicMock(spec=MockEstimator)
+        estimator.create_train_step.return_value = MockTrainStep()
 
         def enrich_fn(batch, miss_idxs, **kwargs):
             # Return fixed value 99.0 for misses
             N = len(miss_idxs)
             return {"values": np.full((N, 1), 99.0, dtype=np.float32)}
 
-        model.enrich.side_effect = enrich_fn
+        estimator.enrich.side_effect = enrich_fn
 
         # Batch with missing key
         batch = MockBatch(keys=np.array([10], dtype=np.uint64))
@@ -194,7 +194,7 @@ def test_estimator_enrich(mock_save_estimator):
         trainable_state.extras = {}
 
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=tmp_dir,
@@ -207,7 +207,7 @@ def test_estimator_enrich(mock_save_estimator):
         )
 
         # Verify
-        assert model.enrich.call_count == 1
+        assert estimator.enrich.call_count == 1
 
         # Flush before verification
         cache_manager.flush()

--- a/tests/caching/test_integration.py
+++ b/tests/caching/test_integration.py
@@ -92,8 +92,8 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         sampler_pass1.shutdown = MagicMock()
 
         train_supervised(
-            model=model,
-            model_config=model_config,
+            estimator=model,
+            estimator_config=model_config,
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=create_state_fn,
@@ -134,8 +134,8 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         model.enrich.reset_mock()
 
         train_supervised(
-            model=model,
-            model_config=model_config,
+            estimator=model,
+            estimator_config=model_config,
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=create_state_fn,
@@ -194,8 +194,8 @@ def test_estimator_enrich(mock_save_estimator):
         trainable_state.extras = {}
 
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=MagicMock(),

--- a/tests/caching/test_raft_integration.py
+++ b/tests/caching/test_raft_integration.py
@@ -91,8 +91,8 @@ def test_raft_integration_caching(mock_save_estimator):
             return jnp.zeros((len(state.history_images), 64, 64, 2))
 
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": True}},
+            estimator=model,
+            estimator_config={"config": {"jit": True}},
             trainable_state=trainable_state,
             out_dir=tmp_dir,
             create_state_fn=create_state_fn,
@@ -140,8 +140,8 @@ def test_raft_integration_caching(mock_save_estimator):
             )
 
             train_supervised(
-                model=model,
-                model_config={"config": {"jit": True}},
+                estimator=model,
+                estimator_config={"config": {"jit": True}},
                 trainable_state=trainable_state,
                 out_dir=tmp_dir,
                 create_state_fn=create_state_fn,

--- a/tests/caching/test_raft_integration.py
+++ b/tests/caching/test_raft_integration.py
@@ -30,8 +30,8 @@ class MiniRaftBatch:
         return self
 
 
-@patch("src.train_supervised.save_model")
-def test_raft_integration_caching(mock_save_model):
+@patch("src.train_supervised.save_estimator")
+def test_raft_integration_caching(mock_save_estimator):
     """Test RaftJaxEstimator caching in the real training loop."""
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/caching/test_raft_integration.py
+++ b/tests/caching/test_raft_integration.py
@@ -36,7 +36,7 @@ def test_raft_integration_caching(mock_save_estimator):
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         # 1. Initialize a mini RAFT estimator
-        model = RaftJaxEstimator(
+        estimator = RaftJaxEstimator(
             patch_size=32,
             patch_stride=32,  # Single patch for 64x64
             hidden_dim=8,  # Tiny
@@ -50,9 +50,13 @@ def test_raft_integration_caching(mock_save_estimator):
         # Create a dummy batch to initialize state
         init_batch = MiniRaftBatch(batch_size=1)
         key = jax.random.PRNGKey(42)
-        trainable_state = model.create_trainable_state(init_batch.images1, key)
+        trainable_state = estimator.create_trainable_state(
+            init_batch.images1, key
+        )
 
-        cache_id = f"raft_test_{model.get_cache_id_suffix(trainable_state)}"
+        cache_id = (
+            f"raft_test_{estimator.get_cache_id_suffix(trainable_state)}"
+        )
         cache_manager = CacheManager(
             root_dir=tmp_dir, cache_id=cache_id, spec={"epe": (np.float32, ())}
         )
@@ -87,11 +91,11 @@ def test_raft_integration_caching(mock_save_estimator):
             )
             return h
 
-        def compute_estimate_fn(model, state, params, rng):
+        def compute_estimate_fn(estimator, state, params, rng):
             return jnp.zeros((len(state.history_images), 64, 64, 2))
 
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": True}},
             trainable_state=trainable_state,
             out_dir=tmp_dir,
@@ -119,14 +123,14 @@ def test_raft_integration_caching(mock_save_estimator):
         assert payload["epe"].shape == (2,)
 
         # 4. Verify that second batch (101, 102) utilized cache for 101
-        # We can check enrich call count on model
+        # We can check enrich call count on estimator
         # But RaftJaxEstimator.enrich is called per batch with miss_idxs
         # If batch 2 had 101 cached, miss_idxs should be [1] (only for 102)
 
         with patch.object(
             RaftJaxEstimator,
             "enrich",
-            wraps=model.enrich,
+            wraps=estimator.enrich,
         ) as mock_miss:
             # Reset sampler for a second "epoch" or another run
             sampler.__iter__.return_value = iter([batch2])
@@ -140,7 +144,7 @@ def test_raft_integration_caching(mock_save_estimator):
             )
 
             train_supervised(
-                estimator=model,
+                estimator=estimator,
                 estimator_config={"config": {"jit": True}},
                 trainable_state=trainable_state,
                 out_dir=tmp_dir,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def mock_sampler():
     sampler.__iter__.return_value = iter([batch] * 10)
     sampler.shutdown = MagicMock()
     sampler.reset = MagicMock()
-    # Set grain_iterator to None so save_model skips sampler serialization
+    # Set grain_iterator to None so save_estimator skips sampler serialization
     sampler.grain_iterator = None
     return sampler
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,12 +100,12 @@ def npy_flow_files(tmp_path):
 
 @pytest.fixture
 def mock_dependencies():
-    """Fixture providing mock model, env, observations for training tests."""
-    model = MagicMock()
-    model.create_train_step.return_value = MagicMock(
+    """Fixture providing mock estimator, env, observations for training tests."""
+    estimator = MagicMock()
+    estimator.create_train_step.return_value = MagicMock(
         return_value=(0.1, MagicMock(), {})
     )
-    model.process_metrics.side_effect = lambda x: x
+    estimator.process_metrics.side_effect = lambda x: x
 
     env = MagicMock()
     # env.reset returns (obs, state, done)
@@ -119,7 +119,7 @@ def mock_dependencies():
     reward = jnp.array([0.0, 0.0])
     env.step.return_value = (obs, env_state, reward, jnp.array([True, True]))
 
-    return model, env, obs, env_state
+    return estimator, env, obs, env_state
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_postprocess_config.py
+++ b/tests/test_postprocess_config.py
@@ -24,7 +24,7 @@ from flowgym.flow.postprocess import (
     tile_average_interpolation,
     universal_median_test,
 )
-from flowgym.make import compile_model
+from flowgym.make import compile_estimator
 from flowgym.utils import load_configuration
 
 config = load_configuration("src/flowgym/config/testing.yaml")
@@ -177,7 +177,7 @@ def test_postprocess_config(B, N, seed):
     # Instantiate the dummy estimator
     model = DummyEstimator.from_config(post_process_config)
     trainable_state = model.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_model(
+    create_state_fn, compute_estimate_fn = compile_estimator(
         model, flow_reference, False
     )
     # Create the state
@@ -265,7 +265,7 @@ def test_postprocess_jit(B, H, time_limit, seed):
     # Instantiate the dummy estimator
     model = DummyEstimator.from_config(post_process_config)
     trainable_state = model.create_trainable_state(image, key=key)
-    create_state_fn, compute_estimate_fn = compile_model(
+    create_state_fn, compute_estimate_fn = compile_estimator(
         model, jnp.zeros((*image.shape, 2)), True
     )
     # Warm up

--- a/tests/test_postprocess_config.py
+++ b/tests/test_postprocess_config.py
@@ -175,10 +175,10 @@ def test_postprocess_config(B, N, seed):
         ]
     }
     # Instantiate the dummy estimator
-    model = DummyEstimator.from_config(post_process_config)
-    trainable_state = model.create_trainable_state(image, key)
+    estimator = DummyEstimator.from_config(post_process_config)
+    trainable_state = estimator.create_trainable_state(image, key)
     create_state_fn, compute_estimate_fn = compile_estimator(
-        model, flow_reference, False
+        estimator, flow_reference, False
     )
     # Create the state
     state = create_state_fn(image, key)
@@ -263,10 +263,10 @@ def test_postprocess_jit(B, H, time_limit, seed):
         ]
     }
     # Instantiate the dummy estimator
-    model = DummyEstimator.from_config(post_process_config)
-    trainable_state = model.create_trainable_state(image, key=key)
+    estimator = DummyEstimator.from_config(post_process_config)
+    trainable_state = estimator.create_trainable_state(image, key=key)
     create_state_fn, compute_estimate_fn = compile_estimator(
-        model, jnp.zeros((*image.shape, 2)), True
+        estimator, jnp.zeros((*image.shape, 2)), True
     )
     # Warm up
     state = create_state_fn(image, key)

--- a/tests/test_preprocess_config.py
+++ b/tests/test_preprocess_config.py
@@ -18,7 +18,7 @@ from flowgym.common.preprocess import (
     resize_image,
     stretch_contrast,
 )
-from flowgym.make import compile_model
+from flowgym.make import compile_estimator
 from flowgym.utils import load_configuration
 
 config = load_configuration("src/flowgym/config/testing.yaml")
@@ -131,10 +131,10 @@ def test_preprocess_config(B, N, seed):
     }
 
     # Instantiate the dummy estimator
-    model = DummyEstimator.from_config(pre_processing_config)
-    trainable_state = model.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_model(
-        model, processed_image_reference, False
+    estimator = DummyEstimator.from_config(pre_processing_config)
+    trainable_state = estimator.create_trainable_state(image, key)
+    create_state_fn, compute_estimate_fn = compile_estimator(
+        estimator, processed_image_reference, False
     )
     # Create the state
     state = create_state_fn(image, key)
@@ -209,9 +209,11 @@ def test_preprocess_jit(B, H, time_limit, seed):
         ]
     }
     # Instantiate the dummy estimator
-    model = DummyEstimator.from_config(pre_processing_config)
-    trainable_state = model.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_model(model, image, True)
+    estimator = DummyEstimator.from_config(pre_processing_config)
+    trainable_state = estimator.create_trainable_state(image, key)
+    create_state_fn, compute_estimate_fn = compile_estimator(
+        estimator, image, True
+    )
     # Warm up
     state = create_state_fn(image, key)
     state, _ = compute_estimate_fn(image, state, trainable_state)

--- a/tests/training/test_checkpointing.py
+++ b/tests/training/test_checkpointing.py
@@ -357,7 +357,7 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
     # 1) Save with Basic Adam
     adam_config = {"name": "adam", "learning_rate": 1e-3}
     tx_adam = build_optimizer_from_config(adam_config)
-    model_adam = MockEstimator(optimizer_config=adam_config)
+    estimator_adam = MockEstimator(optimizer_config=adam_config)
 
     state_save = NNEstimatorTrainableState.create(
         apply_fn=simple_apply_fn, params=params, tx=tx_adam, extras=None
@@ -366,7 +366,7 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
     save_estimator(
         state=state_save,
         out_dir=tmp_path,
-        estimator=model_adam,
+        estimator=estimator_adam,
         estimator_name="RobustTest",
         step=1,
     )

--- a/tests/training/test_checkpointing.py
+++ b/tests/training/test_checkpointing.py
@@ -1,4 +1,4 @@
-"""Tests for model checkpointing"""
+"""Tests for estimator checkpointing."""
 
 import time
 from pathlib import Path
@@ -13,7 +13,7 @@ from flax.core import FrozenDict
 
 from flowgym.common.base.estimator import Estimator
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, make_manager, save_estimator
+from flowgym.make import load_estimator, make_manager, save_estimator
 from flowgym.training.optimizer import build_optimizer_from_config
 
 # ---------------------------------------------------------------------------
@@ -96,14 +96,14 @@ def test_checkpoint_resume_roundtrip(clean_tmp_path):
     )
     state1 = state0.apply_gradients(grads=grads1)  # step should be 1
     step_to_save = int(state1.step)
-    model_name = "DummyEstimator"
+    estimator_name = "DummyEstimator"
 
     # Save checkpoint
     ckpt_dir = save_estimator(
         state=state1,
         out_dir=tmp_path,
         step=step_to_save,
-        estimator_name=model_name,
+        estimator_name=estimator_name,
     )
 
     ckpt_dir = Path(ckpt_dir)
@@ -130,7 +130,7 @@ def test_checkpoint_resume_roundtrip(clean_tmp_path):
     )
 
     # Restore from checkpoint
-    restored_state = load_model(
+    restored_state = load_estimator(
         ckpt_dir=ckpt_dir,
         template_state=template_state,
         mode="resume",
@@ -184,16 +184,16 @@ def test_checkpoint_finetune_with_new_optimizer(clean_tmp_path):
     )
     trained_state = state0.apply_gradients(grads=grads)
     step_to_save = int(trained_state.step)
-    model_name = "DummyEstimator"
+    estimator_name = "DummyEstimator"
 
     # Save checkpoint
     save_estimator(
         state=trained_state,
         out_dir=tmp_path,
         step=step_to_save,
-        estimator_name=model_name,
+        estimator_name=estimator_name,
     )
-    ckpt_dir = tmp_path / "checkpoints" / model_name / str(step_to_save)
+    ckpt_dir = tmp_path / "checkpoints" / estimator_name / str(step_to_save)
     time.sleep(1)
     assert ckpt_dir.exists()
 
@@ -207,7 +207,7 @@ def test_checkpoint_finetune_with_new_optimizer(clean_tmp_path):
     )
 
     # Load only parameters from checkpoint
-    restored_state = load_model(
+    restored_state = load_estimator(
         ckpt_dir=ckpt_dir,
         template_state=template_state,
         mode="params_only",
@@ -259,7 +259,7 @@ def test_finetune_from_params_only_checkpoint_structure_mismatch(
       1) Save checkpoint with *only* params (no TrainState structure).
       2) Build full NNEstimatorTrainableState template
          (params+opt_state+extras).
-      3) Load with load_model(..., mode='params_only'), which currently still
+      3) Load with load_estimator(..., mode='params_only'), which currently still
          builds abstract tree from *full* template_state and hands it to Orbax.
       4) Orbax complains that tree structure on disk (params-only) and the
          requested tree (full state) do not match -> ValueError, as in
@@ -280,7 +280,7 @@ def test_finetune_from_params_only_checkpoint_structure_mismatch(
         )
         mngr.wait_until_finished()
 
-    # We pass the ROOT to load_model so it finds step 0
+    # We pass the ROOT to load_estimator so it finds step 0
     ckpt_to_load = ckpt_root
 
     # 3) Build a full trainable-state template (params + opt_state + extras)
@@ -295,7 +295,7 @@ def test_finetune_from_params_only_checkpoint_structure_mismatch(
     # 4) Try to fine-tune: mode='params_only' but template_state is a full
     #    NNEstimatorTrainableState. With partial_restore=True, this now SUCCEEDS
     #    and restores what it can (params).
-    restored_state = load_model(
+    restored_state = load_estimator(
         ckpt_dir=ckpt_to_load,
         template_state=template_state,
         mode="params_only",
@@ -330,7 +330,7 @@ def test_finetune_from_params_only_checkpoint_works(clean_tmp_path):
     )
 
     # 4) Fine-tune: mode='params_only' should now succeed and give us params
-    restored_state = load_model(
+    restored_state = load_estimator(
         ckpt_dir=ckpt_root,
         template_state=template_state,
         mode="params_only",
@@ -392,7 +392,7 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
     assert leaves_ema > leaves_adam, "EMA should have more leaves"
 
     # 3) Restore should override EMA with Adam from checkpoint
-    restored = load_model(
+    restored = load_estimator(
         ckpt_dir=ckpt_dir, template_state=template_ema, mode="resume"
     )
 

--- a/tests/training/test_checkpointing.py
+++ b/tests/training/test_checkpointing.py
@@ -13,7 +13,7 @@ from flax.core import FrozenDict
 
 from flowgym.common.base.estimator import Estimator
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, make_manager, save_model
+from flowgym.make import load_model, make_manager, save_estimator
 from flowgym.training.optimizer import build_optimizer_from_config
 
 # ---------------------------------------------------------------------------
@@ -99,11 +99,11 @@ def test_checkpoint_resume_roundtrip(clean_tmp_path):
     model_name = "DummyEstimator"
 
     # Save checkpoint
-    ckpt_dir = save_model(
+    ckpt_dir = save_estimator(
         state=state1,
         out_dir=tmp_path,
         step=step_to_save,
-        model_name=model_name,
+        estimator_name=model_name,
     )
 
     ckpt_dir = Path(ckpt_dir)
@@ -187,11 +187,11 @@ def test_checkpoint_finetune_with_new_optimizer(clean_tmp_path):
     model_name = "DummyEstimator"
 
     # Save checkpoint
-    save_model(
+    save_estimator(
         state=trained_state,
         out_dir=tmp_path,
         step=step_to_save,
-        model_name=model_name,
+        estimator_name=model_name,
     )
     ckpt_dir = tmp_path / "checkpoints" / model_name / str(step_to_save)
     time.sleep(1)
@@ -363,11 +363,11 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
         apply_fn=simple_apply_fn, params=params, tx=tx_adam, extras=None
     )
 
-    save_model(
+    save_estimator(
         state=state_save,
         out_dir=tmp_path,
-        model=model_adam,
-        model_name="RobustTest",
+        estimator=model_adam,
+        estimator_name="RobustTest",
         step=1,
     )
     ckpt_dir = tmp_path / "checkpoints" / "RobustTest" / "1"

--- a/tests/training/test_full_integration.py
+++ b/tests/training/test_full_integration.py
@@ -54,7 +54,7 @@ def test_train_supervised_full_integration(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test train_supervised with replay buffer, validation, checkpointing."""
-    model = DummyEstimator(train_type="supervised", enrichment_marker=True)
+    estimator = DummyEstimator(train_type="supervised", enrichment_marker=True)
 
     # Create a separate mock for validation sampler
     val_sampler = MagicMock()
@@ -91,7 +91,7 @@ def test_train_supervised_full_integration(
         }
 
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -126,7 +126,7 @@ def test_train_supervised_replay_enrichment(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test that prepare_experience_for_replay is called and enriches data."""
-    model = DummyEstimator(train_type="supervised", enrichment_marker=True)
+    estimator = DummyEstimator(train_type="supervised", enrichment_marker=True)
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -151,7 +151,7 @@ def test_train_supervised_replay_enrichment(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -179,7 +179,7 @@ def test_train_supervised_checkpointing_roundtrip(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test that checkpoints are saved at the expected intervals."""
-    model = DummyEstimator(train_type="supervised")
+    estimator = DummyEstimator(train_type="supervised")
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -203,7 +203,7 @@ def test_train_supervised_checkpointing_roundtrip(
     # Run training to create a checkpoint
     with patch("train_supervised.save_estimator", side_effect=tracking_save):
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -223,7 +223,7 @@ def test_train_supervised_no_enrichment_without_flag(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test that enrichment is skipped when enrichment_marker is False."""
-    model = DummyEstimator(train_type="supervised", enrichment_marker=False)
+    estimator = DummyEstimator(train_type="supervised", enrichment_marker=False)
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -248,7 +248,7 @@ def test_train_supervised_no_enrichment_without_flag(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -276,7 +276,7 @@ def test_train_supervised_no_enrichment_without_flag(
 
 def test_train_rl_full_integration(tmp_path, mock_env):
     """Test train (RL) loop with replay buffer and checkpointing."""
-    model = DummyEstimator(train_type="rl")
+    estimator = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -307,7 +307,7 @@ def test_train_rl_full_integration(tmp_path, mock_env):
         patch("train.log_flow_estimate"),
     ):
         train(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(out_dir),
@@ -333,7 +333,7 @@ def test_train_rl_full_integration(tmp_path, mock_env):
 
 def test_train_rl_replay_buffer_used(tmp_path, mock_env):
     """Test that replay buffer is initialized and used in RL training."""
-    model = DummyEstimator(train_type="rl")
+    estimator = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -361,7 +361,7 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
         patch("train.log_flow_estimate"),
     ):
         train(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
@@ -383,7 +383,7 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
 
 def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
     """Test that replay buffer sampling is called when replay_ratio > 0."""
-    model = DummyEstimator(train_type="rl")
+    estimator = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -407,7 +407,7 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
 
     # Track train_step_fn calls
     train_step_calls = []
-    original_train_step = model.create_train_step()
+    original_train_step = estimator.create_train_step()
 
     def tracking_train_step(*args, **kwargs):
         train_step_calls.append((args, kwargs))
@@ -415,12 +415,12 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
 
     with (
         patch.object(
-            model, "create_train_step", return_value=tracking_train_step
+            estimator, "create_train_step", return_value=tracking_train_step
         ),
         patch("train.log_flow_estimate"),
     ):
         train(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
@@ -452,7 +452,7 @@ def test_train_supervised_validation_runs(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test that validation is executed at specified intervals."""
-    model = DummyEstimator(train_type="supervised")
+    estimator = DummyEstimator(train_type="supervised")
 
     val_sampler = MagicMock()
     val_sampler.shutdown = MagicMock()
@@ -482,7 +482,7 @@ def test_train_supervised_validation_runs(
         }
 
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -506,7 +506,7 @@ def test_train_supervised_save_only_best(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test save_only_best mode saves only when validation improves."""
-    model = DummyEstimator(train_type="supervised")
+    estimator = DummyEstimator(train_type="supervised")
 
     val_sampler = MagicMock()
     val_sampler.shutdown = MagicMock()
@@ -549,7 +549,7 @@ def test_train_supervised_save_only_best(
         patch("train_supervised.save_estimator", side_effect=tracking_save),
     ):
         train_supervised(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -576,7 +576,7 @@ def test_train_supervised_metrics_logged(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
     """Test that metrics from train step are properly logged."""
-    model = DummyEstimator(train_type="supervised")
+    estimator = DummyEstimator(train_type="supervised")
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -593,7 +593,7 @@ def test_train_supervised_metrics_logged(
 
     # Run training
     train_supervised(
-        estimator=model,
+        estimator=estimator,
         estimator_config={"config": {"jit": False}},
         trainable_state=dummy_trainable_state,
         out_dir=str(out_dir),

--- a/tests/training/test_full_integration.py
+++ b/tests/training/test_full_integration.py
@@ -91,8 +91,8 @@ def test_train_supervised_full_integration(
         }
 
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -151,8 +151,8 @@ def test_train_supervised_replay_enrichment(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -203,8 +203,8 @@ def test_train_supervised_checkpointing_roundtrip(
     # Run training to create a checkpoint
     with patch("train_supervised.save_estimator", side_effect=tracking_save):
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -248,8 +248,8 @@ def test_train_supervised_no_enrichment_without_flag(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -307,8 +307,8 @@ def test_train_rl_full_integration(tmp_path, mock_env):
         patch("train.log_flow_estimate"),
     ):
         train(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -361,8 +361,8 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
         patch("train.log_flow_estimate"),
     ):
         train(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
             create_state_fn=create_state_fn,
@@ -420,8 +420,8 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
         patch("train.log_flow_estimate"),
     ):
         train(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
             create_state_fn=create_state_fn,
@@ -482,8 +482,8 @@ def test_train_supervised_validation_runs(
         }
 
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -549,8 +549,8 @@ def test_train_supervised_save_only_best(
         patch("train_supervised.save_estimator", side_effect=tracking_save),
     ):
         train_supervised(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
             create_state_fn=create_state_fn,
@@ -593,8 +593,8 @@ def test_train_supervised_metrics_logged(
 
     # Run training
     train_supervised(
-        model=model,
-        model_config={"config": {"jit": False}},
+        estimator=model,
+        estimator_config={"config": {"jit": False}},
         trainable_state=dummy_trainable_state,
         out_dir=str(out_dir),
         create_state_fn=create_state_fn,

--- a/tests/training/test_full_integration.py
+++ b/tests/training/test_full_integration.py
@@ -3,7 +3,7 @@
 These tests exercise all training features using DummyEstimator:
 - Replay buffer (initialization, push, sample)
 - Replay buffer enrichment via prepare_experience_for_replay
-- Checkpointing (save_estimator / load_model)
+- Checkpointing (save_estimator)
 - Validation (for train_supervised)
 - Metrics processing
 """

--- a/tests/training/test_full_integration.py
+++ b/tests/training/test_full_integration.py
@@ -3,7 +3,7 @@
 These tests exercise all training features using DummyEstimator:
 - Replay buffer (initialization, push, sample)
 - Replay buffer enrichment via prepare_experience_for_replay
-- Checkpointing (save_model / load_model)
+- Checkpointing (save_estimator / load_model)
 - Validation (for train_supervised)
 - Metrics processing
 """
@@ -27,13 +27,13 @@ from train_supervised import train_supervised
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _mock_save_model(
-    state, out_dir, step=None, model=None, model_name=None, **kwargs
+def _mock_save_estimator(
+    state, out_dir, step=None, estimator=None, estimator_name=None, **kwargs
 ):
-    """Mock save_model that creates checkpoint directories without writing."""
+    """Mock save_estimator that creates checkpoint directories without writing."""
     out_dir = Path(out_dir)
-    if model_name:
-        ckpt_dir = out_dir / "checkpoints" / model_name
+    if estimator_name:
+        ckpt_dir = out_dir / "checkpoints" / estimator_name
     else:
         ckpt_dir = out_dir / "checkpoints"
     ckpt_dir.mkdir(parents=True, exist_ok=True)
@@ -75,10 +75,13 @@ def test_train_supervised_full_integration(
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    # Mock both evaluate_batches and save_model
+    # Mock both evaluate_batches and save_estimator
     with (
         patch("train_supervised.evaluate_batches") as mock_eval,
-        patch("train_supervised.save_model", side_effect=_mock_save_model),
+        patch(
+            "train_supervised.save_estimator",
+            side_effect=_mock_save_estimator,
+        ),
     ):
         mock_eval.return_value = {
             "mean_error": 0.1,
@@ -195,10 +198,10 @@ def test_train_supervised_checkpointing_roundtrip(
 
     def tracking_save(*args, **kwargs):
         save_calls.append((args, kwargs))
-        return _mock_save_model(*args, **kwargs)
+        return _mock_save_estimator(*args, **kwargs)
 
     # Run training to create a checkpoint
-    with patch("train_supervised.save_model", side_effect=tracking_save):
+    with patch("train_supervised.save_estimator", side_effect=tracking_save):
         train_supervised(
             model=model,
             model_config={"config": {"jit": False}},
@@ -212,8 +215,8 @@ def test_train_supervised_checkpointing_roundtrip(
             key=jax.random.PRNGKey(42),
         )
 
-    # Verify save_model was called at expected intervals (batch 3)
-    assert len(save_calls) >= 1, "Expected at least one save_model call"
+    # Verify save_estimator was called at expected intervals (batch 3)
+    assert len(save_calls) >= 1, "Expected at least one save_estimator call"
 
 
 def test_train_supervised_no_enrichment_without_flag(
@@ -298,8 +301,11 @@ def test_train_rl_full_integration(tmp_path, mock_env):
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    # Run training with mocked save_model
-    with patch("train.save_model", side_effect=_mock_save_model):
+    # Run training with mocked save_estimator
+    with (
+        patch("train.save_estimator", side_effect=_mock_save_estimator),
+        patch("train.log_flow_estimate"),
+    ):
         train(
             model=model,
             model_config={"config": {"jit": False}},
@@ -350,7 +356,10 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
         return state, {"dummy": jnp.array(0.0)}
 
     # Track ReplayBuffer initialization
-    with patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer:
+    with (
+        patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer,
+        patch("train.log_flow_estimate"),
+    ):
         train(
             model=model,
             model_config={"config": {"jit": False}},
@@ -404,8 +413,11 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
         train_step_calls.append((args, kwargs))
         return original_train_step(*args, **kwargs)
 
-    with patch.object(
-        model, "create_train_step", return_value=tracking_train_step
+    with (
+        patch.object(
+            model, "create_train_step", return_value=tracking_train_step
+        ),
+        patch("train.log_flow_estimate"),
     ):
         train(
             model=model,
@@ -530,11 +542,11 @@ def test_train_supervised_save_only_best(
 
     def tracking_save(*args, **kwargs):
         save_calls.append((args, kwargs))
-        return _mock_save_model(*args, **kwargs)
+        return _mock_save_estimator(*args, **kwargs)
 
     with (
         patch("train_supervised.evaluate_batches", side_effect=mock_evaluate),
-        patch("train_supervised.save_model", side_effect=tracking_save),
+        patch("train_supervised.save_estimator", side_effect=tracking_save),
     ):
         train_supervised(
             model=model,

--- a/tests/training/test_integrated_checkpointing.py
+++ b/tests/training/test_integrated_checkpointing.py
@@ -9,7 +9,7 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, save_estimator
+from flowgym.make import load_estimator, save_estimator
 
 
 def test_real_integration_checkpointing(tmp_path):
@@ -90,12 +90,12 @@ def test_real_integration_checkpointing(tmp_path):
     )
 
     # 5. SAVE ATOMIC
-    model_name = "IntegrationTest"
+    estimator_name = "IntegrationTest"
     save_path_str = save_estimator(
         state=state,
         out_dir=tmp_path,
         step=10,
-        estimator_name=model_name,
+        estimator_name=estimator_name,
         sampler=sampler,
     )
     save_path = pathlib.Path(save_path_str)
@@ -134,10 +134,12 @@ def test_real_integration_checkpointing(tmp_path):
         )
         print(f"  Batch {i}: ✓ identical")
 
-    # 8. RESTORE MODEL via load_model (Partial Restoring)
+    # 8. RESTORE ESTIMATOR via load_estimator (Partial Restoring)
     template_state = NNEstimatorTrainableState.create(
         apply_fn=apply_fn, params=params, tx=tx
     )
-    restored_model = load_model(save_path, template_state, mode="resume")
-    assert restored_model.step == 10
-    assert jnp.allclose(restored_model.params["w"], state.params["w"])
+    restored_estimator = load_estimator(
+        save_path, template_state, mode="resume"
+    )
+    assert restored_estimator.step == 10
+    assert jnp.allclose(restored_estimator.params["w"], state.params["w"])

--- a/tests/training/test_integrated_checkpointing.py
+++ b/tests/training/test_integrated_checkpointing.py
@@ -9,11 +9,11 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, save_model
+from flowgym.make import load_model, save_estimator
 
 
 def test_real_integration_checkpointing(tmp_path):
-    """Test integration between flowgym.save_model and synthpix.make.
+    """Test integration between flowgym.save_estimator and synthpix.make.
 
     Uses SyntheticImageSampler with real Grain-based scheduler for
     checkpointing.
@@ -91,11 +91,11 @@ def test_real_integration_checkpointing(tmp_path):
 
     # 5. SAVE ATOMIC
     model_name = "IntegrationTest"
-    save_path_str = save_model(
+    save_path_str = save_estimator(
         state=state,
         out_dir=tmp_path,
         step=10,
-        model_name=model_name,
+        estimator_name=model_name,
         sampler=sampler,
     )
     save_path = pathlib.Path(save_path_str)

--- a/tests/training/test_integrated_checkpointing.py
+++ b/tests/training/test_integrated_checkpointing.py
@@ -79,7 +79,7 @@ def test_real_integration_checkpointing(tmp_path):
     next(sampler)
     next(sampler)
 
-    # 4. Prepare Mock Model State
+    # 4. Prepare Mock Estimator State
     def apply_fn(params, x):
         return params["w"] * x
 

--- a/tests/training/test_integrated_checkpointing.py
+++ b/tests/training/test_integrated_checkpointing.py
@@ -79,7 +79,7 @@ def test_real_integration_checkpointing(tmp_path):
     next(sampler)
     next(sampler)
 
-    # 4. Prepare Mock Estimator State
+    # 4. Prepare mock estimator state
     def apply_fn(params, x):
         return params["w"] * x
 
@@ -89,7 +89,7 @@ def test_real_integration_checkpointing(tmp_path):
         apply_fn=apply_fn, params=params, tx=tx
     )
 
-    # 5. SAVE ATOMIC
+    # 5. Save atomically
     estimator_name = "IntegrationTest"
     save_path_str = save_estimator(
         state=state,
@@ -101,7 +101,7 @@ def test_real_integration_checkpointing(tmp_path):
     save_path = pathlib.Path(save_path_str)
     assert save_path.exists()
 
-    # 6. RESTORE SAMPLER via synthpix.make
+    # 6. Restore sampler via synthpix.make
     restored_sampler = synthpix.make(
         dataset_config, use_grain_scheduler=True, load_from=save_path.parent
     )
@@ -134,7 +134,7 @@ def test_real_integration_checkpointing(tmp_path):
         )
         print(f"  Batch {i}: ✓ identical")
 
-    # 8. RESTORE ESTIMATOR via load_estimator (Partial Restoring)
+    # 8. Restore estimator via load_estimator (partial restore)
     template_state = NNEstimatorTrainableState.create(
         apply_fn=apply_fn, params=params, tx=tx
     )

--- a/tests/training/test_partial_checkpointing.py
+++ b/tests/training/test_partial_checkpointing.py
@@ -73,7 +73,7 @@ def _make_real_config(file_list: list[str], dims: dict) -> dict:
     }
 
 
-def _make_model_state() -> NNEstimatorTrainableState:
+def _make_estimator_state() -> NNEstimatorTrainableState:
     """Create a minimal trainable state for checkpointing."""
 
     def apply_fn(params, x):
@@ -153,7 +153,7 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
         next(sampler)
 
         # 3. Create estimator state and save checkpoint
-        estimator_state = _make_model_state()
+        estimator_state = _make_estimator_state()
         estimator_name = "CheckpointTest_synthetic"
 
         save_path_str = save_estimator(
@@ -189,7 +189,7 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
         ), "Flow fields should match"
 
         # 9. Verify estimator state can also be restored independently
-        template_state = _make_model_state()
+        template_state = _make_estimator_state()
         restored_estimator = load_estimator(
             save_path, template_state, mode="resume"
         )
@@ -228,7 +228,7 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
         next(sampler)
 
         # 3. Create estimator state and save checkpoint
-        estimator_state = _make_model_state()
+        estimator_state = _make_estimator_state()
         estimator_name = "CheckpointTest_real"
 
         save_path_str = save_estimator(
@@ -264,7 +264,7 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
         ), "Flow fields should match"
 
         # 9. Verify estimator state can also be restored independently
-        template_state = _make_model_state()
+        template_state = _make_estimator_state()
         restored_estimator = load_estimator(
             save_path, template_state, mode="resume"
         )

--- a/tests/training/test_partial_checkpointing.py
+++ b/tests/training/test_partial_checkpointing.py
@@ -133,7 +133,7 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
     """Test checkpoint/restore cycle for SyntheticImageSampler.
 
     Verifies that:
-    1. flowgym.save_estimator correctly saves sampler state alongside model state
+    1. flowgym.save_estimator correctly saves sampler state alongside estimator state
     2. synthpix.make(load_from=...) correctly restores sampler state
     3. The restored sampler produces identical outputs to original
     """
@@ -152,15 +152,15 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
         next(sampler)
         next(sampler)
 
-        # 3. Create model state and save checkpoint
-        model_state = _make_model_state()
-        model_name = "CheckpointTest_synthetic"
+        # 3. Create estimator state and save checkpoint
+        estimator_state = _make_model_state()
+        estimator_name = "CheckpointTest_synthetic"
 
         save_path_str = save_estimator(
-            state=model_state,
+            state=estimator_state,
             out_dir=tmp_path,
             step=10,
-            estimator_name=model_name,
+            estimator_name=estimator_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)
@@ -188,14 +188,14 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
             restored_batch.flow_fields,
         ), "Flow fields should match"
 
-        # 9. Verify model state can also be restored independently
+        # 9. Verify estimator state can also be restored independently
         template_state = _make_model_state()
         restored_estimator = load_estimator(
             save_path, template_state, mode="resume"
         )
         assert restored_estimator.step == 10, "Estimator step should be restored"
         assert jnp.allclose(
-            restored_estimator.params["w"], model_state.params["w"]
+            restored_estimator.params["w"], estimator_state.params["w"]
         ), "Estimator params should be restored"
     finally:
         sampler.shutdown()
@@ -207,7 +207,7 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
     """Test checkpoint/restore cycle for RealImageSampler.
 
     Verifies that:
-    1. flowgym.save_estimator correctly saves sampler state alongside model state
+    1. flowgym.save_estimator correctly saves sampler state alongside estimator state
     2. synthpix.make(load_from=...) correctly restores sampler state
     3. The restored sampler produces identical outputs to original
     """
@@ -227,15 +227,15 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
         next(sampler)
         next(sampler)
 
-        # 3. Create model state and save checkpoint
-        model_state = _make_model_state()
-        model_name = "CheckpointTest_real"
+        # 3. Create estimator state and save checkpoint
+        estimator_state = _make_model_state()
+        estimator_name = "CheckpointTest_real"
 
         save_path_str = save_estimator(
-            state=model_state,
+            state=estimator_state,
             out_dir=tmp_path,
             step=10,
-            estimator_name=model_name,
+            estimator_name=estimator_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)
@@ -263,14 +263,14 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
             restored_batch.flow_fields,
         ), "Flow fields should match"
 
-        # 9. Verify model state can also be restored independently
+        # 9. Verify estimator state can also be restored independently
         template_state = _make_model_state()
         restored_estimator = load_estimator(
             save_path, template_state, mode="resume"
         )
         assert restored_estimator.step == 10, "Estimator step should be restored"
         assert jnp.allclose(
-            restored_estimator.params["w"], model_state.params["w"]
+            restored_estimator.params["w"], estimator_state.params["w"]
         ), "Estimator params should be restored"
     finally:
         sampler.shutdown()

--- a/tests/training/test_partial_checkpointing.py
+++ b/tests/training/test_partial_checkpointing.py
@@ -1,4 +1,4 @@
-"""Integration tests for checkpoint/resume with flowgym.save_model and synthpix.
+"""Integration tests for checkpoint/resume with flowgym.save_estimator and synthpix.
 
 Tests real save/restore cycles for SyntheticImageSampler and RealImageSampler,
 validating sampler state is preserved across checkpoint boundaries.
@@ -15,7 +15,7 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, save_model
+from flowgym.make import load_model, save_estimator
 
 
 def _make_synthetic_config(file_list: list[str]) -> dict:
@@ -133,7 +133,7 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
     """Test checkpoint/restore cycle for SyntheticImageSampler.
 
     Verifies that:
-    1. flowgym.save_model correctly saves sampler state alongside model state
+    1. flowgym.save_estimator correctly saves sampler state alongside model state
     2. synthpix.make(load_from=...) correctly restores sampler state
     3. The restored sampler produces identical outputs to original
     """
@@ -156,11 +156,11 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
         model_state = _make_model_state()
         model_name = "CheckpointTest_synthetic"
 
-        save_path_str = save_model(
+        save_path_str = save_estimator(
             state=model_state,
             out_dir=tmp_path,
             step=10,
-            model_name=model_name,
+            estimator_name=model_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)
@@ -205,7 +205,7 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
     """Test checkpoint/restore cycle for RealImageSampler.
 
     Verifies that:
-    1. flowgym.save_model correctly saves sampler state alongside model state
+    1. flowgym.save_estimator correctly saves sampler state alongside model state
     2. synthpix.make(load_from=...) correctly restores sampler state
     3. The restored sampler produces identical outputs to original
     """
@@ -229,11 +229,11 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
         model_state = _make_model_state()
         model_name = "CheckpointTest_real"
 
-        save_path_str = save_model(
+        save_path_str = save_estimator(
             state=model_state,
             out_dir=tmp_path,
             step=10,
-            model_name=model_name,
+            estimator_name=model_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)

--- a/tests/training/test_partial_checkpointing.py
+++ b/tests/training/test_partial_checkpointing.py
@@ -15,7 +15,7 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_model, save_estimator
+from flowgym.make import load_estimator, save_estimator
 
 
 def _make_synthetic_config(file_list: list[str]) -> dict:
@@ -190,11 +190,13 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
 
         # 9. Verify model state can also be restored independently
         template_state = _make_model_state()
-        restored_model = load_model(save_path, template_state, mode="resume")
-        assert restored_model.step == 10, "Model step should be restored"
+        restored_estimator = load_estimator(
+            save_path, template_state, mode="resume"
+        )
+        assert restored_estimator.step == 10, "Estimator step should be restored"
         assert jnp.allclose(
-            restored_model.params["w"], model_state.params["w"]
-        ), "Model params should be restored"
+            restored_estimator.params["w"], model_state.params["w"]
+        ), "Estimator params should be restored"
     finally:
         sampler.shutdown()
         if restored_sampler is not None:
@@ -263,11 +265,13 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
 
         # 9. Verify model state can also be restored independently
         template_state = _make_model_state()
-        restored_model = load_model(save_path, template_state, mode="resume")
-        assert restored_model.step == 10, "Model step should be restored"
+        restored_estimator = load_estimator(
+            save_path, template_state, mode="resume"
+        )
+        assert restored_estimator.step == 10, "Estimator step should be restored"
         assert jnp.allclose(
-            restored_model.params["w"], model_state.params["w"]
-        ), "Model params should be restored"
+            restored_estimator.params["w"], model_state.params["w"]
+        ), "Estimator params should be restored"
     finally:
         sampler.shutdown()
         if restored_sampler is not None:

--- a/tests/training/test_sampler_checkpointing.py
+++ b/tests/training/test_sampler_checkpointing.py
@@ -1,4 +1,4 @@
-"""Tests for sampler checkpointing"""
+"""Tests for estimator checkpointing."""
 
 import pathlib
 
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import orbax.checkpoint as ocp
 
 from flowgym.environment.fluid_env import FluidEnv
-from flowgym.make import save_model
+from flowgym.make import save_estimator
 
 
 class DummyState:
@@ -42,8 +42,8 @@ class MockManager:
         pass
 
 
-def test_save_model_is_atomic(monkeypatch):
-    """Test that save_model is atomic"""
+def test_save_estimator_is_atomic(monkeypatch):
+    """Test that save_estimator is atomic."""
     manager_instances = []
 
     def mock_init(ckpt_dir, options=None):
@@ -64,12 +64,12 @@ def test_save_model_is_atomic(monkeypatch):
 
     out_dir = "/tmp/test_ckpt"
 
-    save_model(
+    save_estimator(
         state=state,
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        model_name="TestModel",
+        estimator_name="TestModel",
     )
 
     assert len(manager_instances) == 1
@@ -91,8 +91,8 @@ def test_save_model_is_atomic(monkeypatch):
     assert "grain" in args._items
 
 
-def test_save_model_skips_non_grain_sampler(monkeypatch):
-    """Test that save_model skips non-grain samplers"""
+def test_save_estimator_skips_non_grain_sampler(monkeypatch):
+    """Test that save_estimator skips non-grain samplers."""
     manager_instances = []
 
     def mock_init(ckpt_dir, options=None):
@@ -110,12 +110,12 @@ def test_save_model_skips_non_grain_sampler(monkeypatch):
 
     out_dir = "/tmp/test_ckpt_no_grain"
 
-    save_model(
+    save_estimator(
         state=state,
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        model_name="TestModelNoGrain",
+        estimator_name="TestModelNoGrain",
     )
 
     mngr = manager_instances[0]

--- a/tests/training/test_sampler_checkpointing.py
+++ b/tests/training/test_sampler_checkpointing.py
@@ -69,14 +69,14 @@ def test_save_estimator_is_atomic(monkeypatch):
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        estimator_name="TestModel",
+        estimator_name="TestEstimator",
     )
 
     assert len(manager_instances) == 1
     mngr = manager_instances[0]
 
     expected_path = pathlib.Path(
-        "/tmp/test_ckpt/checkpoints/TestModel"
+        "/tmp/test_ckpt/checkpoints/TestEstimator"
     ).resolve()
     assert pathlib.Path(mngr.ckpt_dir).resolve() == expected_path
 
@@ -115,7 +115,7 @@ def test_save_estimator_skips_non_grain_sampler(monkeypatch):
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        estimator_name="TestModelNoGrain",
+        estimator_name="TestEstimatorNoGrain",
     )
 
     mngr = manager_instances[0]

--- a/tests/training/test_train_replay_integration.py
+++ b/tests/training/test_train_replay_integration.py
@@ -15,8 +15,8 @@ def test_train_replay_initialization(mock_dependencies):
     # We want to check if ReplayBuffer is initialized
     with patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer:
         train(
-            model=model,
-            model_config={"config": {"jit": False}},
+            estimator=model,
+            estimator_config={"config": {"jit": False}},
             trainable_state=MagicMock(),
             out_dir="tmp",
             create_state_fn=lambda img, key: {
@@ -43,8 +43,8 @@ def test_train_replay_execution(mock_dependencies):
     train_step_fn = model.create_train_step.return_value
 
     train(
-        model=model,
-        model_config={"config": {"jit": False}},
+        estimator=model,
+        estimator_config={"config": {"jit": False}},
         trainable_state=MagicMock(),
         out_dir="tmp",
         create_state_fn=lambda img, key: {

--- a/tests/training/test_train_replay_integration.py
+++ b/tests/training/test_train_replay_integration.py
@@ -10,12 +10,12 @@ from train import train
 
 
 def test_train_replay_initialization(mock_dependencies):
-    model, env, obs, env_state = mock_dependencies
+    estimator, env, obs, env_state = mock_dependencies
 
     # We want to check if ReplayBuffer is initialized
     with patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer:
         train(
-            estimator=model,
+            estimator=estimator,
             estimator_config={"config": {"jit": False}},
             trainable_state=MagicMock(),
             out_dir="tmp",
@@ -39,11 +39,11 @@ def test_train_replay_initialization(mock_dependencies):
 
 
 def test_train_replay_execution(mock_dependencies):
-    model, env, obs, env_state = mock_dependencies
-    train_step_fn = model.create_train_step.return_value
+    estimator, env, obs, env_state = mock_dependencies
+    train_step_fn = estimator.create_train_step.return_value
 
     train(
-        estimator=model,
+        estimator=estimator,
         estimator_config={"config": {"jit": False}},
         trainable_state=MagicMock(),
         out_dir="tmp",

--- a/tests/training/test_train_supervised_replay_integration.py
+++ b/tests/training/test_train_supervised_replay_integration.py
@@ -41,8 +41,8 @@ def test_train_supervised_integration_with_replay():
 
     # Call train_supervised
     train_supervised(
-        model=model,
-        model_config={"config": {"jit": False}},
+        estimator=model,
+        estimator_config={"config": {"jit": False}},
         trainable_state=MagicMock(),
         out_dir="/tmp",
         # Use a real dict for state so it can be tree_mapped/stacked

--- a/tests/training/test_train_supervised_replay_integration.py
+++ b/tests/training/test_train_supervised_replay_integration.py
@@ -9,8 +9,8 @@ from train_supervised import train_supervised
 
 def test_train_supervised_integration_with_replay():
     """Verify train_supervised uses the replay buffer."""
-    # Mock model
-    model = MagicMock()
+    # Mock estimator
+    estimator = MagicMock()
     train_step_fn = MagicMock()
 
     # Return dummy values: loss, trainable_state, metrics
@@ -19,10 +19,10 @@ def test_train_supervised_integration_with_replay():
         MagicMock(),
         {"m": jnp.array(0.0)},
     )
-    model.create_train_step.return_value = train_step_fn
-    model.process_metrics.side_effect = lambda x: x
+    estimator.create_train_step.return_value = train_step_fn
+    estimator.process_metrics.side_effect = lambda x: x
     # Mock prepare_experience_for_replay to just return the experience
-    model.prepare_experience_for_replay.side_effect = lambda exp, state: exp
+    estimator.prepare_experience_for_replay.side_effect = lambda exp, state: exp
 
     # Mock sampler
     batch = MagicMock()
@@ -41,7 +41,7 @@ def test_train_supervised_integration_with_replay():
 
     # Call train_supervised
     train_supervised(
-        estimator=model,
+        estimator=estimator,
         estimator_config={"config": {"jit": False}},
         trainable_state=MagicMock(),
         out_dir="/tmp",

--- a/tests/training/test_trainable_state_integration.py
+++ b/tests/training/test_trainable_state_integration.py
@@ -16,7 +16,7 @@ from flowgym.common.base.trainable_state import (
 )
 from flowgym.make import (
     load_model,
-    save_model,
+    save_estimator,
 )
 
 # ---------------------------------------------------------------------------
@@ -169,12 +169,12 @@ def test_apply_gradients_updates_params_and_preserves_tx_and_extras():
 
 
 # ---------------------------------------------------------------------------
-# save_model / load_model: resumability and module-name independence
+# save_estimator / load_model: resumability and module-name independence
 # ---------------------------------------------------------------------------
 
 
 def test_save_and_load_roundtrip_resumable(tmp_path):
-    """Round-trip through save_model/load_model preserves dynamic state."""
+    """Round-trip through save_estimator/load_model preserves dynamic state."""
 
     out_dir = tmp_path
     model_name = "dummy_model"
@@ -185,7 +185,11 @@ def test_save_and_load_roundtrip_resumable(tmp_path):
 
     # Save
     # Save
-    save_model(original_state, out_dir=str(out_dir), model_name=model_name)
+    save_estimator(
+        original_state,
+        out_dir=str(out_dir),
+        estimator_name=model_name,
+    )
     assert ckpt_path.exists(), "Checkpoint directory should be created"
 
     # Build a fresh template_state (as if in a new process)
@@ -220,7 +224,7 @@ def test_save_and_load_supports_training_resumption(tmp_path):
 
     # Path B: train 1 step, save, load, train another step
     s1_b = init_state.apply_gradients(grads=grads1)
-    save_model(s1_b, out_dir=str(out_dir), model_name=model_name)
+    save_estimator(s1_b, out_dir=str(out_dir), estimator_name=model_name)
     assert ckpt_path.exists()
 
     # Fresh template to simulate new process
@@ -252,7 +256,11 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
     tx1 = optax.adam(learning_rate=1e-3)
     original_state = _make_dummy_state(tx=tx1, global_step=10)
 
-    save_model(original_state, out_dir=str(out_dir), model_name=model_name)
+    save_estimator(
+        original_state,
+        out_dir=str(out_dir),
+        estimator_name=model_name,
+    )
     assert ckpt_path.exists()
 
     # Now build a template with *different* tx (e.g., different LR)
@@ -273,13 +281,13 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
     assert loaded_state.tx is tx2
 
 
-def test_save_model_turns_relative_directory_into_absolute(tmp_path):
-    """save_model should convert relative out_dir to absolute path."""
+def test_save_estimator_turns_relative_directory_into_absolute(tmp_path):
+    """save_estimator should convert relative out_dir to absolute path."""
     relative_out_dir = "relative_dir"
     model_name = "test_model"
     # Expected: relative_out_dir/checkpoints/model_name/step_0...
-    # But save_model places it in relative_out_dir/checkpoints/model_name
-    # Return value of save_model is the full step path.
+    # But save_estimator places it in relative_out_dir/checkpoints/model_name
+    # Return value of save_estimator is the full step path.
     # Test checks if directory exists.
     ckpt_path = os.path.abspath(
         os.path.join(relative_out_dir, "checkpoints", model_name)
@@ -288,7 +296,11 @@ def test_save_model_turns_relative_directory_into_absolute(tmp_path):
     state = _make_dummy_state(global_step=0)
 
     # Save using relative path
-    save_model(state, out_dir=relative_out_dir, model_name=model_name)
+    save_estimator(
+        state,
+        out_dir=relative_out_dir,
+        estimator_name=model_name,
+    )
 
     # Check that the checkpoint directory was created at the absolute path
     assert os.path.exists(ckpt_path), (

--- a/tests/training/test_trainable_state_integration.py
+++ b/tests/training/test_trainable_state_integration.py
@@ -184,7 +184,6 @@ def test_save_and_load_roundtrip_resumable(tmp_path):
     original_state = _make_dummy_state(global_step=7)
 
     # Save
-    # Save
     save_estimator(
         original_state,
         out_dir=str(out_dir),

--- a/tests/training/test_trainable_state_integration.py
+++ b/tests/training/test_trainable_state_integration.py
@@ -15,7 +15,7 @@ from flowgym.common.base.trainable_state import (
     NNEstimatorTrainableState,
 )
 from flowgym.make import (
-    load_model,
+    load_estimator,
     save_estimator,
 )
 
@@ -169,16 +169,16 @@ def test_apply_gradients_updates_params_and_preserves_tx_and_extras():
 
 
 # ---------------------------------------------------------------------------
-# save_estimator / load_model: resumability and module-name independence
+# save_estimator / load_estimator: resumability and module-name independence
 # ---------------------------------------------------------------------------
 
 
 def test_save_and_load_roundtrip_resumable(tmp_path):
-    """Round-trip through save_estimator/load_model preserves dynamic state."""
+    """Round-trip through save_estimator/load_estimator preserves dynamic state."""
 
     out_dir = tmp_path
-    model_name = "dummy_model"
-    ckpt_path = out_dir / "checkpoints" / model_name
+    estimator_name = "dummy_estimator"
+    ckpt_path = out_dir / "checkpoints" / estimator_name
 
     # Original state we want to resume later
     original_state = _make_dummy_state(global_step=7)
@@ -188,14 +188,14 @@ def test_save_and_load_roundtrip_resumable(tmp_path):
     save_estimator(
         original_state,
         out_dir=str(out_dir),
-        estimator_name=model_name,
+        estimator_name=estimator_name,
     )
     assert ckpt_path.exists(), "Checkpoint directory should be created"
 
     # Build a fresh template_state (as if in a new process)
     template_state = _make_dummy_state(global_step=0)
 
-    loaded_state = load_model(str(ckpt_path), template_state, mode="resume")
+    loaded_state = load_estimator(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(loaded_state, NNEstimatorTrainableState)
 
@@ -208,8 +208,8 @@ def test_save_and_load_roundtrip_resumable(tmp_path):
 def test_save_and_load_supports_training_resumption(tmp_path):
     """Simulate training, save, load, continue training identically."""
     out_dir = tmp_path
-    model_name = "resumable_model"
-    ckpt_path = out_dir / "checkpoints" / model_name
+    estimator_name = "resumable_estimator"
+    ckpt_path = out_dir / "checkpoints" / estimator_name
 
     # Initial state
     init_state = _make_dummy_state(global_step=0)
@@ -224,12 +224,12 @@ def test_save_and_load_supports_training_resumption(tmp_path):
 
     # Path B: train 1 step, save, load, train another step
     s1_b = init_state.apply_gradients(grads=grads1)
-    save_estimator(s1_b, out_dir=str(out_dir), estimator_name=model_name)
+    save_estimator(s1_b, out_dir=str(out_dir), estimator_name=estimator_name)
     assert ckpt_path.exists()
 
     # Fresh template to simulate new process
     template_state = _make_dummy_state(global_step=0)
-    s1_loaded = load_model(str(ckpt_path), template_state, mode="resume")
+    s1_loaded = load_estimator(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(s1_loaded, NNEstimatorTrainableState)
 
@@ -241,7 +241,7 @@ def test_save_and_load_supports_training_resumption(tmp_path):
     _trees_allclose(s2_direct.extras, s2_resumed.extras)
 
 
-def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
+def test_load_estimator_uses_template_static_tx_not_checkpoint(tmp_path):
     """Static tx must come from the template, not from the checkpoint.
 
     This ensures checkpoints are data-only (params/opt_state/extras) and
@@ -249,8 +249,8 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
     tie them to module/class names.
     """
     out_dir = tmp_path
-    model_name = "dummy_model"
-    ckpt_path = out_dir / "checkpoints" / model_name
+    estimator_name = "dummy_estimator"
+    ckpt_path = out_dir / "checkpoints" / estimator_name
 
     # First state uses tx1 (e.g., Adam with lr=1e-3)
     tx1 = optax.adam(learning_rate=1e-3)
@@ -259,7 +259,7 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
     save_estimator(
         original_state,
         out_dir=str(out_dir),
-        estimator_name=model_name,
+        estimator_name=estimator_name,
     )
     assert ckpt_path.exists()
 
@@ -267,7 +267,7 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
     tx2 = optax.adam(learning_rate=5e-4)
     template_state = _make_dummy_state(tx=tx2, global_step=0)
 
-    loaded_state = load_model(str(ckpt_path), template_state, mode="resume")
+    loaded_state = load_estimator(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(loaded_state, NNEstimatorTrainableState)
 
@@ -284,13 +284,13 @@ def test_load_model_uses_template_static_tx_not_checkpoint(tmp_path):
 def test_save_estimator_turns_relative_directory_into_absolute(tmp_path):
     """save_estimator should convert relative out_dir to absolute path."""
     relative_out_dir = "relative_dir"
-    model_name = "test_model"
-    # Expected: relative_out_dir/checkpoints/model_name/step_0...
-    # But save_estimator places it in relative_out_dir/checkpoints/model_name
+    estimator_name = "test_estimator"
+    # Expected: relative_out_dir/checkpoints/estimator_name/step_0...
+    # But save_estimator places it in relative_out_dir/checkpoints/estimator_name
     # Return value of save_estimator is the full step path.
     # Test checks if directory exists.
     ckpt_path = os.path.abspath(
-        os.path.join(relative_out_dir, "checkpoints", model_name)
+        os.path.join(relative_out_dir, "checkpoints", estimator_name)
     )
 
     state = _make_dummy_state(global_step=0)
@@ -299,7 +299,7 @@ def test_save_estimator_turns_relative_directory_into_absolute(tmp_path):
     save_estimator(
         state,
         out_dir=relative_out_dir,
-        estimator_name=model_name,
+        estimator_name=estimator_name,
     )
 
     # Check that the checkpoint directory was created at the absolute path


### PR DESCRIPTION
## Summary
Reintroduce the estimator API rename across the codebase after the previous merge was reverted from `dev`, but without the last commit that was introduced by mistake.

## What Changed
- rename the remaining public API and internal references from `model` to `estimator`
- remove compatibility shims left over from the earlier transition work
- update CLI entrypoints, training and evaluation paths, caching, and checkpoint-related code
- refresh tests and examples to use the estimator terminology consistently

## Why
`dev` currently contains the revert of the earlier estimator-rename PR, so this branch now represents the clean reapplication of that refactor. However, the last mistake that introduced unnecessary documentation, now has been removed.

## Impact
- restores consistent estimator naming across the API surface
- aligns docs, examples, and tests with the renamed interfaces
- reduces ambiguity between `model` terminology and the current estimator abstraction

Written with the help of Codex