### PR TITLE
style(examples): fix ruff lint failures in caching examples

### DIFF
--- a/examples/10_caching.py
+++ b/examples/10_caching.py
@@ -172,9 +172,7 @@ def run_example():
         dataset_path, estimator_path = setup_configs(temp_dir)
 
         # Run 1: Cold Start
-        duration_1 = run_main(
-            dataset_path, estimator_path, "Run 1: Cold Start"
-        )
+        duration_1 = run_main(dataset_path, estimator_path, "Run 1: Cold Start")
 
         # Modify config to use warm_start="all" for Run 2
         # We rewrite the dataset yaml
@@ -188,9 +186,7 @@ def run_example():
             yaml.dump(config, f)
 
         # Run 2: Warm Start
-        duration_2 = run_main(
-            dataset_path, estimator_path, "Run 2: Warm Start"
-        )
+        duration_2 = run_main(dataset_path, estimator_path, "Run 2: Warm Start")
 
         # Analysis
         if duration_2 < duration_1:

--- a/examples/11_caching.py
+++ b/examples/11_caching.py
@@ -1,4 +1,4 @@
-"""Example of how to use caching with RAFT estimator and temporary .mat files."""
+"""Example of caching with RAFT estimator and temporary .mat files."""
 
 import os
 import subprocess
@@ -188,9 +188,7 @@ def run_example():
         dataset_path, estimator_path = setup_configs(temp_dir)
 
         # Run 1: Cold Start
-        duration_1 = run_main(
-            dataset_path, estimator_path, "Run 1: Cold Start"
-        )
+        duration_1 = run_main(dataset_path, estimator_path, "Run 1: Cold Start")
 
         # Modify config to use warm_start="all" for Run 2
         with open(dataset_path) as f:
@@ -203,9 +201,7 @@ def run_example():
             yaml.dump(config, f)
 
         # Run 2: Warm Start
-        duration_2 = run_main(
-            dataset_path, estimator_path, "Run 2: Warm Start"
-        )
+        duration_2 = run_main(dataset_path, estimator_path, "Run 2: Warm Start")
 
         # Analysis
         if duration_2 < duration_1:


### PR DESCRIPTION
## Summary

Two minor hygiene issues were carried in by #27 and fail ruff on `dev`:

- `E501` in `examples/11_caching.py:1` — the module docstring was 81 chars (one over the configured `line-length = 80`). Reworded to fit.
- `ruff format` would reformat both `examples/10_caching.py` and `examples/11_caching.py` (a few wrapped calls collapsing onto one line). Applied the formatter's output.

No config changes; `pyproject.toml`'s `[tool.ruff] line-length = 80` is left as-is.

## Verification

\`\`\`bash
uv run ruff check examples/10_caching.py examples/11_caching.py
uv run ruff format --check examples/10_caching.py examples/11_caching.py
uv run pre-commit run --files examples/10_caching.py examples/11_caching.py
\`\`\`

All three pass cleanly (ruff legacy alias, ruff format, pydoclint, basedpyright, EOF/whitespace hooks all green; no `--no-verify`).