### PR TITLE
fix(make): use pyright: ignore for orbax checkpoint calls

### DIFF
--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -193,16 +193,18 @@ def save_estimator(
 
     # Define the save arguments
     save_args: dict[str, ocp.args.CheckpointArgs] = {
-        "state": ocp.args.StandardSave(item)  # type: ignore
+        "state": ocp.args.StandardSave(item)  # pyright: ignore[reportCallIssue]
     }
 
     # Extract and save optimizer config separately (as it contains strings)
     if estimator is not None:
         opt_cfg = getattr(
-            estimator, "optimizer_config", getattr(estimator, "opt_config", None)
+            estimator,
+            "optimizer_config",
+            getattr(estimator, "opt_config", None),
         )
         if opt_cfg is not None:
-            save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # type: ignore
+            save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # pyright: ignore[reportCallIssue]
 
     if sampler is not None:
         try:
@@ -210,7 +212,7 @@ def save_estimator(
             # Flatten Composite args to root level for atomic saving
             # of (state, sampler, grain) side-by-side.
             save_args.update(
-                sampler_args.items()  # type: ignore
+                sampler_args.items()  # pyright: ignore[reportAttributeAccessIssue]
             )
         except Exception as e:
             logger.warning(f"Failed to prepare sampler checkpoint args: {e}")


### PR DESCRIPTION
## Summary

Three basedpyright errors fired in `save_estimator` (`src/flowgym/make.py`) on the calls to `ocp.args.StandardSave(item)`, `ocp.args.JsonSave(opt_cfg)`, and `sampler_args.items()`. Each line carried a `# type: ignore` that no longer suppresses basedpyright's `reportCallIssue` / `reportAttributeAccessIssue` rules (basedpyright now requires its own `# pyright: ignore[<rule>]` form for these). The fix swaps the bare `type: ignore` comments for the rule-scoped `pyright: ignore[...]` form so the existing suppressions are actually honored again.

This is a no-op behavioral change: no logic was touched. The commit also picks up a small ruff format reformat of the adjacent `getattr(...)` call that ruff format insists on whenever the file is touched (it was already over the 80-col limit on `dev`).

## Note on project standards

The project standard (`docs/standards/typing-docstrings.md`) discourages introducing new `type: ignore` / `pyright: ignore` comments without flagging them. These three suppressions are pre-existing on `dev`; this PR only converts them to the form basedpyright actually recognizes. No new suppressions are introduced.

## Verification

- `uv sync --group dev --extra other_methods`
- `uv run pre-commit run basedpyright --files src/flowgym/make.py` -> Passed
- `uv run pre-commit run --files src/flowgym/make.py` -> all hooks Passed (ruff, ruff format, pydoclint, basedpyright, end-of-file, trailing-whitespace)
- `uv run python -c "from flowgym.make import save_estimator"` -> imports cleanly
- `uv run pytest tests/training/test_checkpointing.py -q` -> 5 passed in 20.31s