### PR TITLE
Adapt FlowGym to Goggles 0.2 read-only Metrics

### DIFF
--- a/docs/standards/typing-docstrings.md
+++ b/docs/standards/typing-docstrings.md
@@ -6,6 +6,17 @@
 - **Do not include type hints in `Args:` or `Returns:` sections.**
 - Use **Google-style docstrings** with descriptions only.
 
+## Metrics boundary types
+
+- Use plain mutable `dict` objects while building metrics locally.
+- Use Goggles `Metrics` at function boundaries, especially return types and
+  logger-facing APIs.
+- Treat `Metrics` as a read-only mapping. Consumers that need to add or change
+  fields should copy it first with `dict(metrics)`.
+
+This keeps metric construction simple while preventing downstream consumers from
+accidentally mutating producer-owned metric data.
+
 ## Example
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jax>=0.6.0",
     "flax>=0.10.5",
     "ipywidgets",
-    "robo-goggles @ git+https://github.com/antonioterpin/goggles.git@dev",
+    "robo-goggles @ git+https://github.com/antonioterpin/goggles.git@15a2ef28f58d06179d47804ddb908fb58fd06b20",
     "pip>=25.3",
 ]
 
@@ -97,7 +97,7 @@ other_methods = [
 ]
 
 wandb = [
-    "robo-goggles[wandb] @ git+https://github.com/antonioterpin/goggles.git@dev",
+    "robo-goggles[wandb]",
 ]
 
 cuda12 = [

--- a/src/compare.py
+++ b/src/compare.py
@@ -216,7 +216,7 @@ def comparison(
         stats_dict = compute_stats(jnp.array(epe_list))
         write_dicts_to_csv(
             "comparison_results.csv",
-            [stats_dict],
+            [dict(stats_dict)],
         )
 
         logger.info("Comparison completed successfully.")

--- a/src/eval.py
+++ b/src/eval.py
@@ -80,8 +80,7 @@ def eval_flow(
 
     t = time.time() - t
 
-    # Post process the metrics. Convert to a mutable dict locally so the
-    # caller below can add derived fields; expose as ``Metrics`` at return.
+    # Post process the metrics
     metrics = dict(estimator.process_metrics(metrics))
 
     # Extract the flow field from the estimation state
@@ -154,8 +153,7 @@ def eval_density(
     block_until_ready_dict(metrics)
     t = time.time() - t
 
-    # Post process the metrics. Convert to a mutable dict locally so the
-    # caller below can add derived fields; expose as ``Metrics`` at return.
+    # Post process the metrics
     metrics = dict(estimator.process_metrics(metrics))
 
     # Compute the supervised loss if not already provided (e.g., from cache)
@@ -389,8 +387,6 @@ def evaluate_batches(
     # Allow estimator to add derived metrics to the summary
     processed = estimator.process_metrics(dict(summary))
     summary.update(processed)
-    # Expose the locally built dict through Goggles' read-only ``Metrics``
-    # interface.
     return dict(summary)
 
 
@@ -477,9 +473,6 @@ def eval_full_dataset(
             total_time_enriching += time_enriching
 
             t_evaluate_start = time.time()
-            # Convert to a mutable dict locally; the loop below adds and
-            # rewrites fields. The function still returns ``Metrics`` to
-            # callers via the final aggregation step.
             metrics = dict(
                 eval(
                     estimator=estimator,

--- a/src/eval.py
+++ b/src/eval.py
@@ -80,8 +80,9 @@ def eval_flow(
 
     t = time.time() - t
 
-    # Post process the metrics
-    metrics = estimator.process_metrics(metrics)
+    # Post process the metrics. Convert to a mutable dict locally so the
+    # caller below can add derived fields; expose as ``Metrics`` at return.
+    metrics = dict(estimator.process_metrics(metrics))
 
     # Extract the flow field from the estimation state
     flow_field = estimation_state["estimates"][:, -1]
@@ -153,8 +154,9 @@ def eval_density(
     block_until_ready_dict(metrics)
     t = time.time() - t
 
-    # Post process the metrics
-    metrics = estimator.process_metrics(metrics)
+    # Post process the metrics. Convert to a mutable dict locally so the
+    # caller below can add derived fields; expose as ``Metrics`` at return.
+    metrics = dict(estimator.process_metrics(metrics))
 
     # Compute the supervised loss if not already provided (e.g., from cache)
     if "errors" not in metrics:
@@ -228,7 +230,7 @@ def eval(
     else:
         avg_error = np.asarray(metrics["errors"]).mean()
         log += f"Average Density Error: {avg_error:.5f} - "
-    time_evaluating = float(metrics.pop("time"))
+    time_evaluating = float(metrics["time"])
     if time_sample is not None and time_enriching is not None:
         log += (
             f"time_sample: {time_sample:.5f}s - "
@@ -387,7 +389,9 @@ def evaluate_batches(
     # Allow estimator to add derived metrics to the summary
     processed = estimator.process_metrics(dict(summary))
     summary.update(processed)
-    return Metrics(summary)
+    # Expose the locally built dict through Goggles' read-only ``Metrics``
+    # interface.
+    return dict(summary)
 
 
 def eval_full_dataset(
@@ -473,17 +477,22 @@ def eval_full_dataset(
             total_time_enriching += time_enriching
 
             t_evaluate_start = time.time()
-            metrics = eval(
-                estimator=estimator,
-                trainable_state=trainable_state,
-                create_state_fn=create_state_fn,
-                compute_estimate_fn=compute_estimate_fn,
-                batch=batch,
-                estimate_type=estimate_type,
-                key=batch_key,
-                cache_payload=cache_payload,
-                time_sample=time_sample,
-                time_enriching=time_enriching,
+            # Convert to a mutable dict locally; the loop below adds and
+            # rewrites fields. The function still returns ``Metrics`` to
+            # callers via the final aggregation step.
+            metrics = dict(
+                eval(
+                    estimator=estimator,
+                    trainable_state=trainable_state,
+                    create_state_fn=create_state_fn,
+                    compute_estimate_fn=compute_estimate_fn,
+                    batch=batch,
+                    estimate_type=estimate_type,
+                    key=batch_key,
+                    cache_payload=cache_payload,
+                    time_sample=time_sample,
+                    time_enriching=time_enriching,
+                )
             )
             time_evaluating = time.time() - t_evaluate_start
             total_time_evaluating += time_evaluating

--- a/src/flowgym/common/base/estimator.py
+++ b/src/flowgym/common/base/estimator.py
@@ -462,15 +462,11 @@ class Estimator(abc.ABC):
     def process_metrics(self, metrics: dict[str, jnp.ndarray]) -> Metrics:
         """Process metrics after estimation.
 
-        See ``docs/standards/typing-docstrings.md`` for the metrics boundary
-        convention.
-
         Args:
             metrics: The raw metrics from the estimation step.
 
         Returns:
-            Processed metrics exposed through the read-only ``Metrics``
-            interface.
+            Processed metrics.
         """
         # Convert JAX arrays to numpy arrays
         return {k: np.asarray(v) for k, v in metrics.items()}
@@ -479,8 +475,7 @@ class Estimator(abc.ABC):
         """Finalize metrics after evaluation.
 
         Returns:
-            Finalized metrics exposed through the read-only ``Metrics``
-            interface.
+            Finalized metrics.
         """
         return {}
 

--- a/src/flowgym/common/base/estimator.py
+++ b/src/flowgym/common/base/estimator.py
@@ -462,22 +462,27 @@ class Estimator(abc.ABC):
     def process_metrics(self, metrics: dict[str, jnp.ndarray]) -> Metrics:
         """Process metrics after estimation.
 
+        See ``docs/standards/typing-docstrings.md`` for the metrics boundary
+        convention.
+
         Args:
             metrics: The raw metrics from the estimation step.
 
         Returns:
-            Processed metrics.
+            Processed metrics exposed through the read-only ``Metrics``
+            interface.
         """
         # Convert JAX arrays to numpy arrays
-        return Metrics(**{k: np.asarray(v) for k, v in metrics.items()})
+        return {k: np.asarray(v) for k, v in metrics.items()}
 
     def finalize_metrics(self) -> Metrics:
         """Finalize metrics after evaluation.
 
         Returns:
-            Finalized metrics.
+            Finalized metrics exposed through the read-only ``Metrics``
+            interface.
         """
-        return Metrics()
+        return {}
 
     def prepare_experience_for_replay(
         self,

--- a/src/flowgym/flow/consensus/consensus.py
+++ b/src/flowgym/flow/consensus/consensus.py
@@ -301,8 +301,6 @@ class ConsensusFlowEstimator(FlowFieldEstimator):
             else B
         )
 
-        # Build a plain dict locally; expose it as ``Metrics`` at the return
-        # boundary (see ``docs/standards/typing-docstrings.md``).
         processed_metrics: dict = {}
         for key, value in metrics.items():
             if key != "valid_images":

--- a/src/flowgym/flow/consensus/consensus.py
+++ b/src/flowgym/flow/consensus/consensus.py
@@ -301,8 +301,9 @@ class ConsensusFlowEstimator(FlowFieldEstimator):
             else B
         )
 
-        # Convert the raw metrics dictionary into a structured Metrics object
-        processed_metrics = Metrics()
+        # Build a plain dict locally; expose it as ``Metrics`` at the return
+        # boundary (see ``docs/standards/typing-docstrings.md``).
+        processed_metrics: dict = {}
         for key, value in metrics.items():
             if key != "valid_images":
                 filtered_value = (
@@ -384,7 +385,7 @@ class ConsensusFlowEstimator(FlowFieldEstimator):
             TypeError: If log_path is not a string or None.
             ValueError: If log_path doesn't end with .csv.
         """
-        finalized_metrics = Metrics()
+        finalized_metrics: dict = {}
         if hasattr(self, "running_mean_coverage"):
             finalized_metrics["mean_oracle_mask_coverage"] = np.array(
                 self.running_mean_coverage

--- a/src/train.py
+++ b/src/train.py
@@ -137,7 +137,7 @@ def train(
                 t = time.time() - t
 
                 # Post process, log and append the metrics
-                metrics = estimator.process_metrics(metrics)
+                metrics = dict(estimator.process_metrics(metrics))
                 logger.push(metrics, step=episode_idx)
 
                 # Extract the action (the last estimate)

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -171,7 +171,7 @@ def train_supervised(
                     elif isinstance(v, np.ndarray) and v.ndim == 0:
                         init_val_msg += f", {k}={float(v):.5f}"
                 logger.info(init_val_msg)
-                last_val_metrics = val_metrics
+                last_val_metrics = dict(val_metrics)
                 best_mean_error = mean_error
             except Exception as e:
                 logger.error(f"Initial validation failed: {e}")
@@ -371,7 +371,7 @@ def train_supervised(
                         elif isinstance(v, np.ndarray) and v.ndim == 0:
                             val_msg += f", {k}={float(v):.5f}"
                     logger.info(val_msg)
-                    last_val_metrics = val_metrics
+                    last_val_metrics = dict(val_metrics)
 
                 if batch_idx % log_every == 0:
                     logger.scalar("loss", float(loss), step=batch_idx)

--- a/uv.lock
+++ b/uv.lock
@@ -1003,8 +1003,8 @@ requires-dist = [
     { name = "openpiv", marker = "extra == 'other-methods'" },
     { name = "pip", specifier = ">=25.3" },
     { name = "pyoptflow", marker = "extra == 'other-methods'" },
-    { name = "robo-goggles", git = "https://github.com/antonioterpin/goggles.git?rev=dev" },
-    { name = "robo-goggles", extras = ["wandb"], marker = "extra == 'wandb'", git = "https://github.com/antonioterpin/goggles.git?rev=dev" },
+    { name = "robo-goggles", git = "https://github.com/antonioterpin/goggles.git?rev=15a2ef28f58d06179d47804ddb908fb58fd06b20" },
+    { name = "robo-goggles", extras = ["wandb"], marker = "extra == 'wandb'" },
     { name = "torch", marker = "extra == 'other-methods'", specifier = ">=1.13.1" },
     { name = "torchvision", marker = "extra == 'other-methods'", specifier = ">=0.14.1" },
 ]
@@ -2228,12 +2228,6 @@ wheels = [
 ]
 
 [[package]]
-name = "netifaces"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/91/86a6eac449ddfae239e93ffc1918cf33fd9bab35c04d1e963b311e347a73/netifaces-0.11.0.tar.gz", hash = "sha256:043a79146eb2907edf439899f262b3dfe41717d34124298ed281139a8b93ca32", size = 30106, upload-time = "2021-05-31T08:33:02.506Z" }
-
-[[package]]
 name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2778,18 +2772,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
-
-[[package]]
-name = "portal"
-version = "3.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "msgpack" },
-    { name = "numpy" },
-    { name = "psutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/03dcd20105d0009751e2df903ab06b2141f4cd448e87911bab36429f8094/portal-3.7.3.tar.gz", hash = "sha256:543b8e177d22b2efb3c3a966ab0164871ef6a31a5cf60faf2d45286b3efd969b", size = 27395, upload-time = "2025-04-20T21:35:00.858Z" }
 
 [[package]]
 name = "pre-commit"
@@ -3350,17 +3332,12 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.1.9"
-source = { git = "https://github.com/antonioterpin/goggles.git?rev=dev#0c1cb6d2f8c4a155f54ecdda7ff05a60c5d6e6ea" }
+version = "0.2.0"
+source = { git = "https://github.com/antonioterpin/goggles.git?rev=15a2ef28f58d06179d47804ddb908fb58fd06b20#15a2ef28f58d06179d47804ddb908fb58fd06b20" }
 dependencies = [
-    { name = "basedpyright" },
     { name = "imageio" },
     { name = "matplotlib" },
-    { name = "netifaces" },
     { name = "numpy" },
-    { name = "portal" },
-    { name = "pydoclint" },
-    { name = "pyyaml" },
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typing-extensions" },
@@ -3368,6 +3345,7 @@ dependencies = [
 
 [package.optional-dependencies]
 wandb = [
+    { name = "plotly" },
     { name = "wandb", extra = ["media"] },
 ]
 


### PR DESCRIPTION
## Summary

- Build metrics locally as plain `dict`; expose as `Metrics` only at return/logging boundaries (Goggles 0.2's `Metrics` is a read-only `Mapping` and is no longer constructible).
- Where a function consumes a `Metrics`-typed value and mutates it, copy via `dict(metrics)` first.
- Pin `robo-goggles` to commit `15a2ef28` (Goggles 0.2 release SHA used in private `dev`) and re-lock.
- Add `docs/standards/typing-docstrings.md` describing the boundary convention.

## Why

This is the public-side counterpart to `IDSCETHZurich/fluids-estimation#149` (which adapted private FlowGym to Goggles 0.2). It is a hand port rather than a cherry-pick: public `dev`'s `eval.py` and `train.py` have evolved differently from private `dev` (no `cache_payload` short-circuit, post `refactor/rename-estimator-api`), so #149's diff does not apply directly. The semantic change is small and uniform — five `Metrics(...)` constructor sites on public `dev` plus the downstream callers that expected the old mutable shape.

## Files touched

- `src/flowgym/common/base/estimator.py` — `process_metrics` / `finalize_metrics` return plain dicts.
- `src/flowgym/flow/consensus/consensus.py` — same in the consensus estimator's `process_metrics` / `finalize_metrics`.
- `src/eval.py`, `src/train.py`, `src/train_supervised.py`, `src/compare.py` — wrap `estimator.process_metrics(...)` in `dict(...)` at sites where the local value is later mutated; `metrics.pop("time")` → `metrics["time"]`.
- `pyproject.toml` + `uv.lock` — pin update.
- `docs/standards/typing-docstrings.md` — boundary-convention doc (mirrors private side).

## Validation

- `uv lock` resolves; `uv sync` installs.
- `uv run basedpyright src/` — only pre-existing unrelated errors remain (cv2/torch/openpiv import resolutions, dead `# pyright: ignore` markers in `farneback.py` / `deepflow.py` / `dis.py`, `make.py` issues). All 0 new errors from this PR's surface.
- `uv run pytest tests/base_estimator tests/consensus tests/test_estimation_stats.py --no-cov -q` — 186 passed.

## Follow-up (separate)

The ADMM consolidation (merging `feat-admm` and `feat-admm-experiments`) will rebase on top of this branch / on `dev` after merge, so the consolidated ADMM branch starts on the Goggles 0.2 baseline.