### PR TITLE
chore: restore dev-side improvements lost in ADMM cherry-picks

### DIFF
--- a/src/flowgym/flow/consensus/admm.py
+++ b/src/flowgym/flow/consensus/admm.py
@@ -15,6 +15,56 @@ from flowgym.flow.consensus.types import (
 from flowgym.utils import DEBUG
 
 
+def _compute_stopping_criteria(
+    flows_new: jax.Array,
+    consensus_flow_new: jax.Array,
+    consensus_flow: jax.Array,
+    consensus_dual_new: jax.Array,
+    rho: float,
+    eps_abs: float,
+    eps_rel: float,
+    total_decision_vars: int,
+    N: int,
+) -> tuple[jax.Array, ...]:
+    """Compute residuals for ADMM stopping criteria.
+
+    Args:
+        flows_new: Updated flow estimates from different agents.
+        consensus_flow_new: Updated consensus flow estimate.
+        consensus_flow: Previous consensus flow estimate.
+        consensus_dual_new: Updated dual variable for consensus.
+        rho: Penalty parameter for the consensus term.
+        eps_abs: Absolute tolerance for stopping criterion.
+        eps_rel: Relative tolerance for stopping criterion.
+        total_decision_vars: Total number of decision variables.
+        N: Number of agents.
+
+    Returns:
+        Tuple containing primal residual, dual residual, primal epsilon,
+        dual epsilon, flows norm, and consensus norm.
+    """
+    primal_residual = jnp.linalg.norm(flows_new - consensus_flow_new[None, ...])
+    dual_residual = (
+        rho * jnp.sqrt(N) * jnp.linalg.norm(consensus_flow_new - consensus_flow)
+    )
+    flows_norm = jnp.linalg.norm(flows_new)
+    consensus_norm = jnp.sqrt(N) * jnp.linalg.norm(consensus_flow_new)
+    eps_pri = jnp.sqrt(total_decision_vars) * eps_abs + eps_rel * jnp.maximum(
+        flows_norm, consensus_norm
+    )
+    eps_dual = jnp.sqrt(
+        total_decision_vars
+    ) * eps_abs + eps_rel * rho * jnp.linalg.norm(consensus_dual_new)
+    return (
+        primal_residual,
+        dual_residual,
+        eps_pri,
+        eps_dual,
+        flows_norm,
+        consensus_norm,
+    )
+
+
 def run_admm(
     flows: jax.Array,
     rho: float,
@@ -188,24 +238,24 @@ def run_admm(
 
         if (eps_rel is not None) and (eps_abs is not None):
             # Apply stopping criteria based on eps_abs and eps_rel
-
-            # Stopping conditions (per batch)
-            primal_residual = jnp.linalg.norm(
-                flows_new - consensus_flow_new[None, ...]
+            (
+                primal_residual,
+                dual_residual,
+                eps_pri,
+                eps_dual,
+                flows_norm,
+                consensus_norm,
+            ) = _compute_stopping_criteria(
+                flows_new,
+                consensus_flow_new,
+                consensus_flow,
+                consensus_dual_new,
+                rho,
+                eps_abs,
+                eps_rel,
+                total_decision_vars,
+                N,
             )
-            dual_residual = (
-                rho
-                * jnp.sqrt(N)
-                * jnp.linalg.norm(consensus_flow_new - consensus_flow)
-            )
-            flows_norm = jnp.linalg.norm(flows_new)
-            consensus_norm = jnp.sqrt(N) * jnp.linalg.norm(consensus_flow_new)
-            eps_pri = jnp.sqrt(
-                total_decision_vars
-            ) * eps_abs + eps_rel * jnp.maximum(flows_norm, consensus_norm)
-            eps_dual = jnp.sqrt(
-                total_decision_vars
-            ) * eps_abs + eps_rel * rho * jnp.linalg.norm(consensus_dual_new)
 
             # Update active mask (per batch item)
             active_new: jax.Array = (primal_residual > eps_pri) | (

--- a/src/flowgym/flow/consensus/regularizers.py
+++ b/src/flowgym/flow/consensus/regularizers.py
@@ -98,7 +98,7 @@ def total_regularization_loss(
         weights: Weights for each regularizer.
 
     Returns:
-        jnp.ndarray: Total regularization loss as a scalar.
+        Total regularization loss as a scalar.
     """
     total = 0.0
     for name in regularizers:

--- a/tests/consensus/test_consensus.py
+++ b/tests/consensus/test_consensus.py
@@ -236,6 +236,16 @@ def test_median_consensus_dtype_preserved(flows):
     assert result.dtype == jnp.float32
 
 
+@pytest.mark.parametrize("rho", ["a", [1.0], None, {}])
+def test_invalid_rho_type(rho):
+    """Test ADMM consensus with invalid rho type."""
+    flows = jnp.zeros((2, 3, 4, 4, 2))
+    weights = jnp.ones((2, 3, 4, 4))  # Dummy weights
+    config = {"rho": rho}
+    with pytest.raises(TypeError, match="Invalid rho type"):
+        admm_consensus(flows, weights, config)
+
+
 @pytest.mark.parametrize("rho", [0, -1.5, -1, -1e-6])
 def test_invalid_rho_value(rho):
     """Test ADMM consensus with non-positive rho."""


### PR DESCRIPTION
## Summary

Three small reverts that snuck in via the cherry-picks from `feat-admm-experiments` — same root cause as the `utils.py` revert fixed in #37: those branches forked from `main` before commit `3a888ae` ("feat: release private updates") landed on dev, so replaying their content on top of current `dev` overwrote dev's improvements.

This PR restores them. Targets `feat-admm-consolidated` so the cleanup is reviewable independently of the broader ADMM consolidation in #34.

## Changes

### `flow/consensus/admm.py` — re-extract `_compute_stopping_criteria` helper
The 6-line residual computation was inlined directly into `run_admm` on the consolidated branch but exists as a named helper on dev. Logic is byte-identical; this restores the structural improvement.

### `flow/consensus/regularizers.py` — drop redundant docstring type prefix
```diff
  Returns:
- jnp.ndarray: Total regularization loss as a scalar.
+ Total regularization loss as a scalar.
```

### `tests/consensus/test_consensus.py` — restore `test_invalid_rho_type`
Test was dropped from `feat-admm-experiments` (likely because the consolidated branch's impl raises `TypeError` instead of dev's `ValueError`, breaking the test). Restored, updated to expect `TypeError`.

## Why TypeError, not ValueError

The consolidated branch raises `TypeError` for the rho type check; dev raises `ValueError` with a message that says "Invalid rho type". The consolidated form is the more correct one:
- Exception class matches the message.
- Matches the project-wide convention (TypeError for type, ValueError for value, as cleaned up in #37).

The runtime check itself is **load-bearing**, despite the typing convention: `rho` is extracted via `cfg.pop("rho", 1.0)` from a `dict[str, Any]`, so pyright sees `Any` and can't enforce type at the call site.

## Skipped (deliberately not restored)

The `Invalid weights type` runtime check and its `test_invalid_flow_weights_type` test were dropped on the consolidated branch. **Not restored.** `weights: jax.Array` is statically typed at every call site, so the runtime `isinstance(weights, jnp.ndarray)` guard is exactly the redundant pattern PR #37 cleaned up. The drop is consistent with the typing convention.

## Test plan

- [x] `pytest tests/consensus/` — 73/73 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)