### PR TITLE
feat(target_transforms): add log transform with safe default eps

### DIFF
--- a/src/flowgym/training/target_transforms.py
+++ b/src/flowgym/training/target_transforms.py
@@ -82,6 +82,21 @@ def _scale(x: jax.Array, factor: float = 1.0) -> jax.Array:
     return x * factor
 
 
+def _log(x: jax.Array, eps: float = 1e-8) -> jax.Array:
+    """Log transform with epsilon and non-negative clamp.
+
+    Args:
+        x: Input array.
+        eps: Small positive constant added before log. Defaults to ``1e-8``
+            so a bare ``name: log`` config never injects ``-inf`` on exact
+            zeros (EPE targets/rewards can be 0).
+
+    Returns:
+        Log of (max(x, 0) + eps).
+    """
+    return jnp.log(jnp.maximum(x, 0.0) + eps)
+
+
 TransformFn = Callable[..., jax.Array]
 
 TRANSFORM_REGISTRY: dict[str, TransformFn] = {
@@ -90,6 +105,7 @@ TRANSFORM_REGISTRY: dict[str, TransformFn] = {
     "sqrt": _sqrt,
     "clip": _clip,
     "scale": _scale,
+    "log": _log,
 }
 
 
@@ -131,6 +147,12 @@ def build_target_transform_from_config(
     """
     if config is None:
         return _identity
+
+    if not isinstance(config, dict):
+        config_type = type(config).__name__
+        raise TypeError(
+            f"Target transform config must be a dictionary; got {config_type}"
+        )
 
     if "pipeline" in config:
         pipeline = config["pipeline"]

--- a/tests/unit/training/test_target_transforms.py
+++ b/tests/unit/training/test_target_transforms.py
@@ -69,6 +69,28 @@ def test_build_scale():
     assert jnp.allclose(transform(x), expected)
 
 
+def test_build_log():
+    """log transform clamps negatives to zero, adds eps, then applies log."""
+    # Explicit eps applied after clamping negatives to zero.
+    config = {"name": "log", "eps": 1.0}
+    transform = build_target_transform_from_config(config)
+    x = jnp.array([-1.0, 0.0, 1.0, 10.0])
+    expected = jnp.log(jnp.array([0.0, 0.0, 1.0, 10.0]) + 1.0)
+    assert jnp.allclose(transform(x), expected)
+
+    # Default eps is a safe positive so a bare ``name: log`` config does not
+    # produce -inf on exact zeros (e.g. EPE targets that can be 0).
+    transform = build_target_transform_from_config({"name": "log"})
+    out = transform(jnp.array([0.0, 1.0, 10.0]))
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_non_dict_config_raises():
+    """A non-dict, non-None config raises a descriptive TypeError."""
+    with pytest.raises(TypeError, match="must be a dictionary"):
+        build_target_transform_from_config(["not", "a", "dict"])  # type: ignore[arg-type]
+
+
 def test_build_pipeline():
     """pipeline config composes transforms left-to-right in declared order."""
     config = {


### PR DESCRIPTION
## Summary
- Add a `"log"` target transform that clamps negatives to zero and adds a small eps (default `1e-8`) before `jnp.log`, so a bare `name: log` config never injects `-inf` on exact-zero targets (EPE can be 0).
- Guard `build_target_transform_from_config` against non-dict configs with a descriptive `TypeError`.

Ported from the private `fluids-estimation` dev branch (commits 8e6e236, 6a89ed0). Public's existing docstrings are preserved.

## Test plan
- [x] `pytest tests/unit/training/test_target_transforms.py` (11 passed)