### PR TITLE
feat(nn): convert RAFT32-PIV PyTorch checkpoint to Flax params

### DIFF
--- a/src/flowgym/flow/raft/raft_piv_pytorch.py
+++ b/src/flowgym/flow/raft/raft_piv_pytorch.py
@@ -1,5 +1,7 @@
 """RAFT_torch class."""
 
+from __future__ import annotations
+
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/src/flowgym/nn/raft_torch_to_jax.py
+++ b/src/flowgym/nn/raft_torch_to_jax.py
@@ -1,0 +1,226 @@
+"""Convert a PyTorch RAFT32-PIV checkpoint into Flax/JAX parameters.
+
+The PyTorch model is defined in ``flowgym.nn.raft_torch_nn`` and the
+Flax counterpart in ``flowgym.nn.raft_model``. Both implement the same
+RAFT architecture but with different parameter naming. This module
+builds an explicit mapping between PyTorch state-dict keys and the
+nested Flax parameter tree produced by ``RaftEstimatorModel.init``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import jax.numpy as jnp
+import numpy as np
+
+# PyTorch conv weights: (out_channels, in_channels, kH, kW)
+# Flax Conv kernels:    (kH, kW, in_channels, out_channels)
+_CONV_PERM = (2, 3, 1, 0)
+
+# Six ResidualBlocks per EncoderBlock, in PyTorch addressing.
+_ENCODER_RESIDUALS: tuple[tuple[int, int], ...] = (
+    (1, 0),
+    (1, 1),
+    (2, 0),
+    (2, 1),
+    (3, 0),
+    (3, 1),
+)
+
+
+def _torch_conv_to_jax(
+    weight: np.ndarray, bias: np.ndarray
+) -> dict[str, jnp.ndarray]:
+    """Convert a single PyTorch conv layer to Flax ``Conv`` parameters.
+
+    Args:
+        weight: PyTorch conv weight of shape ``(out, in, kH, kW)``.
+        bias: PyTorch conv bias of shape ``(out,)``.
+
+    Returns:
+        Dict with ``kernel`` and ``bias`` arrays in Flax convention.
+    """
+    return {
+        "kernel": jnp.asarray(weight.transpose(_CONV_PERM)),
+        "bias": jnp.asarray(bias),
+    }
+
+
+def _encoder_params(
+    sd: Mapping[str, np.ndarray], prefix: str
+) -> dict[str, dict]:
+    """Build Flax params for a single ``EncoderBlock``.
+
+    Args:
+        sd: Source PyTorch state dict (numpy arrays).
+        prefix: Either ``"fnet"`` or ``"cnet"``.
+
+    Returns:
+        Nested params dict matching ``EncoderBlock`` keys.
+    """
+    out: dict[str, dict] = {}
+
+    # First 7x7 conv: PyTorch conv1 -> Flax ConvBlock_0/Conv_0
+    out["ConvBlock_0"] = {
+        "Conv_0": _torch_conv_to_jax(
+            sd[f"{prefix}.conv1.weight"], sd[f"{prefix}.conv1.bias"]
+        )
+    }
+
+    # Six residual blocks, in declaration order.
+    for idx, (layer, sub) in enumerate(_ENCODER_RESIDUALS):
+        base = f"{prefix}.layer{layer}.{sub}"
+        out[f"ResidualBlock_{idx}"] = {
+            "ConvBlock_0": {
+                "Conv_0": _torch_conv_to_jax(
+                    sd[f"{base}.conv1.weight"], sd[f"{base}.conv1.bias"]
+                )
+            },
+            "ConvBlock_1": {
+                "Conv_0": _torch_conv_to_jax(
+                    sd[f"{base}.conv2.weight"], sd[f"{base}.conv2.bias"]
+                )
+            },
+            # 1x1 skip/projection. The torch ResidualBlock always carries
+            # a ``downsample.0`` 1x1 conv (even when stride == 1), which
+            # the Flax ResidualBlock mirrors via its top-level ``Conv_0``.
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{base}.downsample.0.weight"],
+                sd[f"{base}.downsample.0.bias"],
+            ),
+        }
+
+    # Output 1x1 conv: PyTorch conv2 -> Flax ConvBlock_1/Conv_0
+    out["ConvBlock_1"] = {
+        "Conv_0": _torch_conv_to_jax(
+            sd[f"{prefix}.conv2.weight"], sd[f"{prefix}.conv2.bias"]
+        )
+    }
+
+    return out
+
+
+def _update_block_params(sd: Mapping[str, np.ndarray]) -> dict[str, dict]:
+    """Build Flax params for the ``UpdateBlock``.
+
+    Args:
+        sd: Source PyTorch state dict (numpy arrays).
+
+    Returns:
+        Nested params dict matching ``UpdateBlock`` keys.
+    """
+    p: dict[str, dict] = {}
+
+    # Motion encoder.
+    enc = "update_block.encoder"
+    p["MotionEncoderBlock_0"] = {
+        "ConvBlock_0": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{enc}.convc1.weight"], sd[f"{enc}.convc1.bias"]
+            )
+        },
+        "ConvBlock_1": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{enc}.convc2.weight"], sd[f"{enc}.convc2.bias"]
+            )
+        },
+        "ConvBlock_2": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{enc}.convf1.weight"], sd[f"{enc}.convf1.bias"]
+            )
+        },
+        "ConvBlock_3": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{enc}.convf2.weight"], sd[f"{enc}.convf2.bias"]
+            )
+        },
+        "ConvBlock_4": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{enc}.conv.weight"], sd[f"{enc}.conv.bias"]
+            )
+        },
+    }
+
+    # Separable conv GRU: horizontal (z1, r1, q1), then vertical (z2, r2, q2).
+    gru = "update_block.gru"
+    gru_torch_names = (
+        "convz1",
+        "convr1",
+        "convq1",
+        "convz2",
+        "convr2",
+        "convq2",
+    )
+    p["SepConvGRUBlock_0"] = {
+        f"ConvBlock_{i}": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{gru}.{name}.weight"], sd[f"{gru}.{name}.bias"]
+            )
+        }
+        for i, name in enumerate(gru_torch_names)
+    }
+
+    # Flow head: conv1 then conv2.
+    fh = "update_block.flow_head"
+    p["FlowHeadBlock_0"] = {
+        "ConvBlock_0": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{fh}.conv1.weight"], sd[f"{fh}.conv1.bias"]
+            )
+        },
+        "ConvBlock_1": {
+            "Conv_0": _torch_conv_to_jax(
+                sd[f"{fh}.conv2.weight"], sd[f"{fh}.conv2.bias"]
+            )
+        },
+    }
+
+    # Upsampling mask head: nn.Sequential indices 0 and 2 (index 1 is ReLU).
+    p["ConvBlock_0"] = {
+        "Conv_0": _torch_conv_to_jax(
+            sd["update_block.mask.0.weight"], sd["update_block.mask.0.bias"]
+        )
+    }
+    p["ConvBlock_1"] = {
+        "Conv_0": _torch_conv_to_jax(
+            sd["update_block.mask.2.weight"], sd["update_block.mask.2.bias"]
+        )
+    }
+
+    return p
+
+
+def convert_raft_torch_state_dict(
+    state_dict: Mapping[str, Any],
+) -> dict[str, dict]:
+    """Convert a PyTorch RAFT32 state dict to a Flax params pytree.
+
+    Missing keys propagate as ``KeyError`` from the indexing below.
+
+    Args:
+        state_dict: PyTorch ``model_state_dict`` for
+            :class:`flowgym.nn.raft_torch_nn.flowNetsRAFT.RAFT`. Values
+            may be either ``numpy`` arrays or ``torch.Tensor``; in the
+            latter case they are converted to numpy via ``.cpu().numpy()``.
+
+    Returns:
+        Nested params dict consumable as ``{"params": <returned>}`` by
+        :class:`flowgym.nn.raft_model.RaftEstimatorModel`.
+    """
+    # Normalize values to numpy (handle torch.Tensor without importing torch).
+    sd: dict[str, np.ndarray] = {}
+    for k, v in state_dict.items():
+        if hasattr(v, "detach"):
+            sd[k] = cast(Any, v).detach().cpu().numpy()
+        else:
+            sd[k] = np.asarray(v)
+
+    # In ``RaftEstimatorModel``, ``EncoderBlock_0`` is fnet and
+    # ``EncoderBlock_1`` is cnet (creation order in ``__call__``).
+    return {
+        "EncoderBlock_0": _encoder_params(sd, "fnet"),
+        "EncoderBlock_1": _encoder_params(sd, "cnet"),
+        "UpdateBlock_0": _update_block_params(sd),
+    }

--- a/tests/unit/nn/test_raft_torch_to_jax.py
+++ b/tests/unit/nn/test_raft_torch_to_jax.py
@@ -1,0 +1,353 @@
+"""Tests for the PyTorch -> JAX RAFT32-PIV checkpoint converter."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from flowgym.nn.raft_model import RaftEstimatorModel
+from flowgym.nn.raft_torch_to_jax import convert_raft_torch_state_dict
+
+PATCH_SIZE = 32
+
+# Per-ResidualBlock (in_channels, out_channels), in declaration order.
+_ENCODER_RESIDUAL_PROGRESSION: tuple[tuple[int, int], ...] = (
+    (64, 64),
+    (64, 64),
+    (64, 96),
+    (96, 96),
+    (96, 128),
+    (128, 128),
+)
+
+_ENCODER_LAYER_IDS: tuple[tuple[int, int], ...] = (
+    (1, 0),
+    (1, 1),
+    (2, 0),
+    (2, 1),
+    (3, 0),
+    (3, 1),
+)
+
+# (weight_shape, bias_shape) for every update_block conv.
+_UPDATE_BLOCK_SHAPES: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {
+    "update_block.encoder.convc1": ((256, 324, 1, 1), (256,)),
+    "update_block.encoder.convc2": ((192, 256, 3, 3), (192,)),
+    "update_block.encoder.convf1": ((128, 2, 7, 7), (128,)),
+    "update_block.encoder.convf2": ((64, 128, 3, 3), (64,)),
+    "update_block.encoder.conv": ((126, 256, 3, 3), (126,)),
+    "update_block.gru.convz1": ((128, 384, 1, 5), (128,)),
+    "update_block.gru.convr1": ((128, 384, 1, 5), (128,)),
+    "update_block.gru.convq1": ((128, 384, 1, 5), (128,)),
+    "update_block.gru.convz2": ((128, 384, 5, 1), (128,)),
+    "update_block.gru.convr2": ((128, 384, 5, 1), (128,)),
+    "update_block.gru.convq2": ((128, 384, 5, 1), (128,)),
+    "update_block.flow_head.conv1": ((256, 128, 3, 3), (256,)),
+    "update_block.flow_head.conv2": ((2, 256, 3, 3), (2,)),
+    "update_block.mask.0": ((256, 128, 3, 3), (256,)),
+    "update_block.mask.2": ((576, 256, 1, 1), (576,)),
+}
+
+
+def _make_numpy_state_dict(seed: int = 0) -> dict[str, np.ndarray]:
+    """Build a torch-shaped RAFT32 state dict using only numpy.
+
+    The values are deterministic random arrays of the exact shapes the
+    PyTorch ``RAFT`` module would produce, so the converter can be
+    exercised end-to-end without a torch dependency.
+
+    Args:
+        seed: Seed for the deterministic RNG.
+
+    Returns:
+        A dict mapping torch parameter names to numpy arrays.
+    """
+    rng = np.random.default_rng(seed)
+    sd: dict[str, np.ndarray] = {}
+
+    def _add_encoder(prefix: str, output_dim: int) -> None:
+        sd[f"{prefix}.conv1.weight"] = rng.standard_normal(
+            (64, 1, 7, 7), dtype=np.float32
+        )
+        sd[f"{prefix}.conv1.bias"] = rng.standard_normal(
+            (64,), dtype=np.float32
+        )
+        for (in_p, p), (layer_idx, sub) in zip(
+            _ENCODER_RESIDUAL_PROGRESSION, _ENCODER_LAYER_IDS, strict=True
+        ):
+            base = f"{prefix}.layer{layer_idx}.{sub}"
+            sd[f"{base}.conv1.weight"] = rng.standard_normal(
+                (p, in_p, 3, 3), dtype=np.float32
+            )
+            sd[f"{base}.conv1.bias"] = rng.standard_normal(
+                (p,), dtype=np.float32
+            )
+            sd[f"{base}.conv2.weight"] = rng.standard_normal(
+                (p, p, 3, 3), dtype=np.float32
+            )
+            sd[f"{base}.conv2.bias"] = rng.standard_normal(
+                (p,), dtype=np.float32
+            )
+            sd[f"{base}.downsample.0.weight"] = rng.standard_normal(
+                (p, in_p, 1, 1), dtype=np.float32
+            )
+            sd[f"{base}.downsample.0.bias"] = rng.standard_normal(
+                (p,), dtype=np.float32
+            )
+        sd[f"{prefix}.conv2.weight"] = rng.standard_normal(
+            (output_dim, 128, 1, 1), dtype=np.float32
+        )
+        sd[f"{prefix}.conv2.bias"] = rng.standard_normal(
+            (output_dim,), dtype=np.float32
+        )
+
+    _add_encoder("fnet", output_dim=256)
+    _add_encoder("cnet", output_dim=256)
+
+    for name, (w_shape, b_shape) in _UPDATE_BLOCK_SHAPES.items():
+        sd[f"{name}.weight"] = rng.standard_normal(w_shape, dtype=np.float32)
+        sd[f"{name}.bias"] = rng.standard_normal(b_shape, dtype=np.float32)
+
+    return sd
+
+
+def _build_jax_model() -> RaftEstimatorModel:
+    """Construct the Flax counterpart with the production RAFT32 config.
+
+    Returns:
+        The Flax ``RaftEstimatorModel`` in inference mode.
+    """
+    return RaftEstimatorModel(
+        hidden_dim=128,
+        context_dim=128,
+        corr_levels=4,
+        corr_radius=4,
+        iters=12,
+        norm_fn="instance",
+        dropout=0.0,
+        train=False,
+    )
+
+
+def _jax_param_template() -> dict:
+    """Return the params pytree produced by ``RaftEstimatorModel.init``.
+
+    Returns:
+        A nested params dict with the canonical RAFT32 shapes.
+    """
+    model = _build_jax_model()
+    dummy = jnp.zeros((1, PATCH_SIZE, PATCH_SIZE, 2), dtype=jnp.float32)
+    return model.init(jax.random.PRNGKey(0), dummy, dummy)["params"]
+
+
+def test_converted_params_match_jax_param_tree():
+    """Converted params must have the exact tree/shape as ``model.init``.
+
+    Runs in the default test environment: depends only on numpy + JAX.
+    """
+    state_dict = _make_numpy_state_dict()
+    converted = convert_raft_torch_state_dict(state_dict)
+
+    template = _jax_param_template()
+    flat_template = jax.tree_util.tree_map(lambda x: x.shape, template)
+    flat_converted = jax.tree_util.tree_map(lambda x: x.shape, converted)
+    assert flat_template == flat_converted
+
+
+def test_converted_values_round_trip_through_param_template():
+    """Converted leaves match the source state dict, byte-for-byte.
+
+    Each Flax leaf is the corresponding torch tensor transposed into Flax
+    convention (``(out, in, kH, kW) -> (kH, kW, in, out)`` for kernels).
+    Validate this against the source ``state_dict`` without any torch
+    dependency, so the core converter is exercised in the default env.
+    """
+    state_dict = _make_numpy_state_dict(seed=7)
+    converted = convert_raft_torch_state_dict(state_dict)
+
+    # Spot-check both an encoder kernel and an update-block kernel.
+    fnet_conv1 = converted["EncoderBlock_0"]["ConvBlock_0"]["Conv_0"]
+    expected = state_dict["fnet.conv1.weight"].transpose(2, 3, 1, 0)
+    np.testing.assert_array_equal(np.asarray(fnet_conv1["kernel"]), expected)
+    np.testing.assert_array_equal(
+        np.asarray(fnet_conv1["bias"]), state_dict["fnet.conv1.bias"]
+    )
+
+    mask_head = converted["UpdateBlock_0"]["ConvBlock_1"]["Conv_0"]
+    expected_mask = state_dict["update_block.mask.2.weight"].transpose(
+        2, 3, 1, 0
+    )
+    np.testing.assert_array_equal(
+        np.asarray(mask_head["kernel"]), expected_mask
+    )
+    np.testing.assert_array_equal(
+        np.asarray(mask_head["bias"]), state_dict["update_block.mask.2.bias"]
+    )
+
+
+def test_converter_accepts_objects_with_detach_method():
+    """The converter normalises tensor-like inputs via ``.detach().cpu()``.
+
+    Use a tiny duck-typed stand-in (no torch import) to exercise the
+    branch that handles tensor objects.
+    """
+
+    class _FakeTensor:
+        def __init__(self, array: np.ndarray):
+            self._array = array
+
+        def detach(self) -> _FakeTensor:
+            return self
+
+        def cpu(self) -> _FakeTensor:
+            return self
+
+        def numpy(self) -> np.ndarray:
+            return self._array
+
+    numpy_sd = _make_numpy_state_dict(seed=11)
+    fake_sd = {k: _FakeTensor(v) for k, v in numpy_sd.items()}
+
+    from_numpy = convert_raft_torch_state_dict(numpy_sd)
+    from_fake = convert_raft_torch_state_dict(fake_sd)
+
+    leaves_a = jax.tree_util.tree_leaves(from_numpy)
+    leaves_b = jax.tree_util.tree_leaves(from_fake)
+    for a, b in zip(leaves_a, leaves_b, strict=True):
+        np.testing.assert_array_equal(np.asarray(a), np.asarray(b))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# PyTorch parity tests — slow and require the optional ``torch`` dependency.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class _Args:
+    """Minimal argparse-like holder consumed by ``RAFT.forward``."""
+
+    amp = False
+    iters = 12
+
+
+def _torch_to_jax_inputs(torch_module, img1: np.ndarray, img2: np.ndarray):
+    """Build matching torch and JAX inputs from two raw image arrays.
+
+    Args:
+        torch_module: The imported ``torch`` module (passed in so this
+            helper does not import torch at module scope).
+        img1: First-frame batch, shape ``(B, 1, H, W)``.
+        img2: Second-frame batch, same shape as ``img1``.
+
+    Returns:
+        Tuple ``(torch_input, jax_input)``. ``torch_input`` is already
+        normalised to ``[0, 1]`` to match how the upstream pipeline
+        invokes RAFT; ``jax_input`` is the raw ``(B, H, W, 2)`` stack
+        consumed by ``RaftEstimatorModel`` (which normalises internally).
+    """
+    torch_input = torch_module.from_numpy(
+        np.concatenate([img1, img2], axis=1) / 256.0
+    )
+    jax_input = jnp.asarray(
+        np.concatenate([img1, img2], axis=1).transpose(0, 2, 3, 1)
+    )
+    return torch_input, jax_input
+
+
+def _build_torch_raft_with_state(state_dict):
+    """Instantiate the PyTorch RAFT model and load ``state_dict`` into it.
+
+    Args:
+        state_dict: PyTorch state dict for the RAFT model. Any ``warp.*``
+            buffer keys are dropped (they are not part of ``RAFT``).
+
+    Returns:
+        The loaded RAFT model in ``eval`` mode.
+    """
+    from flowgym.nn.raft_torch_nn.flowNetsRAFT import RAFT
+
+    sd = {k: v for k, v in state_dict.items() if not k.startswith("warp.")}
+    model = RAFT()
+    model.load_state_dict(sd)
+    model.eval()
+    return model
+
+
+@pytest.mark.slow
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_converted_model_matches_pytorch_output():
+    """Outputs of converted JAX model must match PyTorch RAFT closely."""
+    torch = pytest.importorskip("torch")
+
+    torch.manual_seed(0)
+    from flowgym.nn.raft_torch_nn.flowNetsRAFT import RAFT
+
+    state_dict = RAFT().state_dict()
+    torch_model = _build_torch_raft_with_state(state_dict)
+    params = convert_raft_torch_state_dict(state_dict)
+    jax_model = _build_jax_model()
+
+    rng = np.random.default_rng(42)
+    img1 = rng.uniform(0, 255, size=(1, 1, PATCH_SIZE, PATCH_SIZE)).astype(
+        np.float32
+    )
+    img2 = rng.uniform(0, 255, size=(1, 1, PATCH_SIZE, PATCH_SIZE)).astype(
+        np.float32
+    )
+
+    torch_input, jax_input = _torch_to_jax_inputs(torch, img1, img2)
+    with torch.no_grad():
+        flow_preds, _ = torch_model(
+            torch_input, torch.zeros_like(torch_input), args=_Args()
+        )
+    torch_out = flow_preds[-1].numpy()  # (B, 2, H, W)
+
+    flow_init = jnp.zeros((1, PATCH_SIZE, PATCH_SIZE, 2), dtype=jnp.float32)
+    jax_iters = jax_model.apply({"params": params}, jax_input, flow_init)
+    jax_out = np.asarray(jax_iters[-1]).transpose(0, 3, 1, 2)  # (B, 2, H, W)
+
+    # The Flax ``ConvBlock`` runs its inner conv in float16, while the
+    # PyTorch reference is driven in float32 here, so an exact match is not
+    # achievable. The tolerance below comfortably absorbs the resulting
+    # mixed-precision error on a 32x32 patch with [0, 1)-scaled inputs.
+    np.testing.assert_allclose(jax_out, torch_out, atol=2e-2, rtol=5e-2)
+
+
+@pytest.mark.slow
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+def test_all_intermediate_flow_iterations_match():
+    """All 12 refinement iterations should agree, not just the last one."""
+    torch = pytest.importorskip("torch")
+
+    torch.manual_seed(0)
+    from flowgym.nn.raft_torch_nn.flowNetsRAFT import RAFT
+
+    state_dict = RAFT().state_dict()
+    torch_model = _build_torch_raft_with_state(state_dict)
+    params = convert_raft_torch_state_dict(state_dict)
+    jax_model = _build_jax_model()
+
+    rng = np.random.default_rng(123)
+    img1 = rng.uniform(0, 255, size=(2, 1, PATCH_SIZE, PATCH_SIZE)).astype(
+        np.float32
+    )
+    img2 = rng.uniform(0, 255, size=(2, 1, PATCH_SIZE, PATCH_SIZE)).astype(
+        np.float32
+    )
+
+    torch_input, jax_input = _torch_to_jax_inputs(torch, img1, img2)
+    with torch.no_grad():
+        flow_preds, _ = torch_model(
+            torch_input, torch.zeros_like(torch_input), args=_Args()
+        )
+
+    flow_init = jnp.zeros((2, PATCH_SIZE, PATCH_SIZE, 2), dtype=jnp.float32)
+    jax_iters = jax_model.apply({"params": params}, jax_input, flow_init)
+    jax_iters_np = np.asarray(jax_iters).transpose(0, 1, 4, 2, 3)
+
+    assert len(flow_preds) == jax_iters_np.shape[0] == 12
+    for i, torch_flow in enumerate(flow_preds):
+        np.testing.assert_allclose(
+            jax_iters_np[i], torch_flow.numpy(), atol=2e-2, rtol=5e-2
+        )


### PR DESCRIPTION
## Summary
- Add `convert_raft_torch_state_dict` (`flowgym/nn/raft_torch_to_jax.py`) to map a RAFT32-PIV PyTorch state dict onto the Flax `RaftEstimatorModel` parameter tree, enabling reuse of pretrained PyTorch weights in the JAX estimator.
- Add `from __future__ import annotations` to `raft_piv_pytorch.py` (required by the converter's annotations).

Ported from the private `fluids-estimation` dev branch (PR #156, commits 0a226a7, 6ba2d43). Self-contained — no ArtOfPIV coupling.

## Test plan
- [x] `pytest tests/unit/nn/test_raft_torch_to_jax.py` with `other_methods` extra (torch) — 5 passed