### PR TITLE
fix(caching): populate all spec columns on index hits + deterministic dups

### DIFF
--- a/src/flowgym/training/caching.py
+++ b/src/flowgym/training/caching.py
@@ -157,6 +157,14 @@ class CacheManager:
         if not files:
             return
 
+        # Deterministic duplicate-key policy across parts:
+        # prefer values from newer parquet files.
+        files = sorted(
+            files,
+            key=lambda p: (p.stat().st_mtime_ns, str(p)),
+            reverse=True,
+        )
+
         num_files = len(files)
         logger.info(
             f"Warm-starting cache ({self.warm_start}) from {num_files} files..."
@@ -187,12 +195,18 @@ class CacheManager:
             )
 
         elif self.warm_start == "index":
+            best_stamp_by_key: dict[int, tuple[int, str]] = {}
             for f in files:
+                stamp = (f.stat().st_mtime_ns, str(f))
                 table = pq.read_table(f, columns=["key"])
                 keys = table["key"].to_numpy()
                 file_path = str(f)
                 for i, k in enumerate(keys):
-                    self.index[int(k)] = (file_path, i)
+                    key_int = int(k)
+                    prev_stamp = best_stamp_by_key.get(key_int)
+                    if prev_stamp is None or stamp > prev_stamp:
+                        self.index[key_int] = (file_path, i)
+                        best_stamp_by_key[key_int] = stamp
             logger.info(f"Loaded {len(self.index)} keys into index.")
 
     def _lookup_pending_buffer(
@@ -211,9 +225,14 @@ class CacheManager:
             hit_mask: Boolean array marking which keys were found.
             payload_out: Output payload dictionary to fill.
         """
+        # Prefer the latest pending value for duplicate keys.
+        latest_pos: dict[int, int] = {}
+        for idx, key in enumerate(self.pending_buffer["key"]):
+            latest_pos[key] = idx
+
         for i, k in enumerate(keys_int):
-            if k in self.pending_buffer["key"]:
-                idx = self.pending_buffer["key"].index(k)
+            idx = latest_pos.get(k)
+            if idx is not None:
                 for name in self.spec:
                     payload_out[name][i] = self.pending_buffer[name][idx]
                 hit_mask[i] = True
@@ -295,12 +314,16 @@ class CacheManager:
             if not row_idxs:
                 continue
             sub = table.take(pa.array(row_idxs, type=pa.int64()))
-            for name in self.spec:
-                values = sub[name].to_pylist()
-                for i, v in zip(input_idxs, values, strict=True):
-                    if not hit_mask[i]:
-                        payload_out[name][i] = v
-                        hit_mask[i] = True
+            # Materialise every spec column once, then write all fields for
+            # each row before flipping hit_mask — otherwise the second-and-
+            # onward spec entries would be skipped.
+            values_by_name = {name: sub[name].to_pylist() for name in self.spec}
+            for pos, i in enumerate(input_idxs):
+                if hit_mask[i]:
+                    continue
+                for name in self.spec:
+                    payload_out[name][i] = values_by_name[name][pos]
+                hit_mask[i] = True
 
     def _process_parquet_file(
         self,

--- a/tests/unit/training/caching/test_caching.py
+++ b/tests/unit/training/caching/test_caching.py
@@ -8,7 +8,6 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
-import pytest
 
 from flowgym.training.caching import CacheManager
 
@@ -155,14 +154,11 @@ def test_lookup_all_warm_start_handles_duplicate_requested_keys():
         np.testing.assert_allclose(payload["values"], [[1.0, 1.0], [1.0, 1.0]])
 
 
-@pytest.mark.xfail(
-    reason="CacheManager returns oldest part for duplicate keys; see #44",
-    strict=False,
-)
 def test_lookup_disk_prefers_newest_part_for_duplicate_keys():
     """Disk lookup should deterministically prefer the newest parquet part."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         cache_id = "test_disk_dupe_policy"
+        data_dir = Path(tmp_dir) / cache_id / "data"
         cm = CacheManager(
             tmp_dir, cache_id, spec={"values": (np.float32, (1,))}
         )
@@ -172,17 +168,23 @@ def test_lookup_disk_prefers_newest_part_for_duplicate_keys():
             {"values": np.array([[1.0]], dtype=np.float32)},
         )
         cm.flush()
+        first_files = set(data_dir.glob("*.parquet"))
+        assert len(first_files) == 1, "Expected one parquet file after flush"
 
         cm.write(
             np.array([7], dtype=np.uint64),
             {"values": np.array([[2.0]], dtype=np.float32)},
         )
         cm.flush()
+        all_files = set(data_dir.glob("*.parquet"))
+        assert len(all_files) == 2, "Expected two parquet files for two flushes"
 
-        files = sorted((Path(tmp_dir) / cache_id / "data").glob("*.parquet"))
-        assert len(files) == 2, "Expected two parquet files for two flushes"
-        os.utime(files[0], (1, 1))
-        os.utime(files[1], (2, 2))
+        # Identify the parts by write order, not by (random uuid) filename, then
+        # stamp mtimes so the second write (value 2.0) is unambiguously newest.
+        older = first_files.pop()
+        newer = (all_files - first_files).pop()
+        os.utime(older, (1, 1))
+        os.utime(newer, (2, 2))
 
         cm_read = CacheManager(
             tmp_dir, cache_id, spec={"values": (np.float32, (1,))}

--- a/tests/unit/training/caching/test_generic_caching.py
+++ b/tests/unit/training/caching/test_generic_caching.py
@@ -86,6 +86,40 @@ def test_warm_start_all_generic():
         )
 
 
+def test_index_lookup_populates_all_spec_columns():
+    """An index warm-start hit must fill every spec column, not just the
+    first. Regression: the per-column loop flipped hit_mask while writing the
+    first field, so subsequent fields were skipped and read back as zeros."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        cache_id = "test_index_multicol"
+        spec = {
+            "epe": (np.float32, ()),
+            "scores": (np.float32, (3,)),
+        }
+
+        cm_write = CacheManager(tmp_dir, cache_id, spec=spec)
+        keys = np.array([7], dtype=np.uint64)
+        payload = {
+            "epe": np.array([0.5], dtype=np.float32),
+            "scores": np.array([[1.0, 2.0, 3.0]], dtype=np.float32),
+        }
+        cm_write.write(keys, payload)
+        cm_write.close()
+
+        # Warm start by index so the hit is served from the on-disk parquet
+        # via _lookup_index (the path that carried the bug).
+        cm_read = CacheManager(
+            tmp_dir, cache_id, spec=spec, warm_start="index"
+        )
+        payload_out, hit = cm_read.lookup(keys)
+
+        assert bool(hit[0])
+        np.testing.assert_allclose(payload_out["epe"][0], payload["epe"][0])
+        np.testing.assert_allclose(
+            payload_out["scores"][0], payload["scores"][0]
+        )
+
+
 def test_enrich_generic():
     """enrich_batch writes computed values to the pending buffer on a miss."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- **Correctness fix**: in the index-lookup path, the per-column loop flipped `hit_mask` while writing the *first* spec field, so every subsequent field was skipped and read back as zeros. Now all columns are materialised once and every field is written per row before flipping the mask.
- **Determinism**: warm-start sorts parquet files newest-first; the `"index"` warm-start keeps the newest file per duplicate key; the pending-buffer lookup prefers the latest value for a key.

Ported rename-free from the private `fluids-estimation` dev `caching.py` (the private diff also carried an `estimator`→`model` rename, which is intentionally excluded here and will land as its own PR).

## Test plan
- [x] New regression test `test_index_lookup_populates_all_spec_columns` (fails on old code, passes now)
- [x] `pytest tests/unit/training/caching tests/integration/caching` (48 passed, 3 skipped, 1 xfailed)