### PR TITLE
refactor(make): rename estimator API to model (compile/save/load_model)

### DIFF
--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -59,8 +59,8 @@ def make_manager(ckpt_dir: Path, keep: int = 3) -> ocp.CheckpointManager:
 
 
 @overload
-def compile_estimator(
-    estimator: Estimator,
+def compile_model(
+    model: Estimator,
     estimates: None,
     jit: bool = True,
     history_size: int = 1,
@@ -71,8 +71,8 @@ def compile_estimator(
 
 
 @overload
-def compile_estimator(
-    estimator: Estimator,
+def compile_model(
+    model: Estimator,
     estimates: jnp.ndarray,
     jit: bool = True,
     history_size: int = 1,
@@ -82,8 +82,8 @@ def compile_estimator(
 ]: ...
 
 
-def compile_estimator(
-    estimator: Estimator,
+def compile_model(
+    model: Estimator,
     estimates: jnp.ndarray | None,
     jit: bool = True,
     history_size: int = 1,
@@ -91,13 +91,13 @@ def compile_estimator(
     CompiledCreateStateFn | None,
     CompiledComputeEstimateFn,
 ]:
-    """Compile the estimator for JAX.
+    """Compile the model for JAX.
 
     Args:
-        estimator: The flow field estimator instance.
+        model: The flow field model instance.
         estimates: Example estimates for shape inference.
         jit: Whether to use JIT compilation.
-        history_size: The size of the history for the estimator.
+        history_size: The size of the history for the model.
 
     Returns:
         Compiled functions.
@@ -106,7 +106,7 @@ def compile_estimator(
     if estimates is not None:
 
         def create_state_fn_impl(images: jnp.ndarray, rng: PRNGKey) -> History:
-            return estimator.create_state(
+            return model.create_state(
                 images,
                 estimates=estimates,
                 image_history_size=history_size,
@@ -124,7 +124,7 @@ def compile_estimator(
         trainable_state: EstimatorTrainableState,
         cache_payload: CachePayload | None = None,
     ) -> tuple[History, dict]:
-        return estimator(
+        return model(
             images, state, trainable_state, cache_payload=cache_payload
         )
 
@@ -135,25 +135,25 @@ def compile_estimator(
     return create_state_fn, compute_estimate_fn
 
 
-def save_estimator(
+def save_model(
     state: NNEstimatorTrainableState,
     out_dir: str | Path,
     step: int | None = None,
-    estimator: Estimator | None = None,
-    estimator_name: str | None = None,
+    model: Estimator | None = None,
+    model_name: str | None = None,
     sampler: Any | None = None,
     keep: int = 3,
 ) -> str:
     """Save a training checkpoint using Orbax.
 
-    Checkpoint saved to out_dir/checkpoints/<estimator_name>/<step>.
+    Checkpoint saved to out_dir/checkpoints/<model_name>/<step>.
 
     Args:
         state: The trainable state to save (PyTree).
         out_dir: Root output directory for this experiment/run.
         step: Training step/batch index. If None, reads from `state.step`.
-        estimator: The estimator instance (to extract optimizer_config).
-        estimator_name: Optional estimator name for directory nesting.
+        model: The model instance (to extract optimizer_config).
+        model_name: Optional model name for directory nesting.
         sampler: The sampler instance to save (must be Sampler with
             Grain scheduler for full state saving).
         keep: Number of checkpoints to keep.
@@ -175,10 +175,10 @@ def save_estimator(
             raise ValueError("step not provided and state has no 'step' attr")
     step = int(step)
 
-    # Nesting: out_dir/checkpoints/<estimator_name>/<step>
+    # Nesting: out_dir/checkpoints/<model_name>/<step>
     parts = [out_dir, "checkpoints"]
-    if estimator_name is not None:
-        parts.append(estimator_name)
+    if model_name is not None:
+        parts.append(model_name)
 
     ckpt_root = Path(*parts)
     ckpt_root.mkdir(parents=True, exist_ok=True)
@@ -197,11 +197,11 @@ def save_estimator(
     }
 
     # Extract and save optimizer config separately (as it contains strings)
-    if estimator is not None:
+    if model is not None:
         opt_cfg = getattr(
-            estimator,
+            model,
             "optimizer_config",
-            getattr(estimator, "opt_config", None),
+            getattr(model, "opt_config", None),
         )
         if opt_cfg is not None:
             save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # pyright: ignore[reportCallIssue]
@@ -224,7 +224,7 @@ def save_estimator(
     return str(ckpt_root / str(step))
 
 
-def load_estimator(
+def load_model(
     ckpt_dir: str | Path,
     template_state: NNEstimatorTrainableState,
     mode: Literal["resume", "params_only"] = "params_only",
@@ -518,7 +518,7 @@ def make_estimator(
                 jnp.zeros(image_shape, dtype=jnp.float32), key=rng
             )
             if isinstance(template_state, NNEstimatorTrainableState):
-                trained_state = load_estimator(
+                trained_state = load_model(
                     load_from, template_state, mode=mode
                 )
             else:
@@ -549,7 +549,7 @@ def make_estimator(
         dummy_estimates = None
     else:
         dummy_estimates = jnp.zeros(estimate_shape, dtype=jnp.float32)
-    create_state_fn, compute_estimate_fn = compile_estimator(
+    create_state_fn, compute_estimate_fn = compile_model(
         estimator,
         dummy_estimates,
         estimator_config["config"].get("jit", False) and not DEBUG,

--- a/src/flowgym/types.py
+++ b/src/flowgym/types.py
@@ -272,8 +272,8 @@ class CompiledCreateStateFn(Protocol):
     """Protocol for the compiled state creation function.
 
     NOTE: This protocol is for the create-state callable returned by
-    `make_estimator`/`compile_estimator`, not `Estimator.create_state`.
-    `compile_estimator` binds `estimates` and history sizes ahead of time.
+    `make_estimator`/`compile_model`, not `Estimator.create_state`.
+    `compile_model` binds `estimates` and history sizes ahead of time.
     """
 
     def __call__(

--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from goggles import Metrics
 
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
 from flowgym.environment.fluid_env import EnvState, FluidEnv, Observation
-from flowgym.make import save_estimator
+from flowgym.make import save_model
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
     CompiledComputeEstimateFn,
@@ -255,11 +255,11 @@ def train(
                 logger.info(f"Episode {episode_idx} - {k}: {avg_value}")
 
             if episode_idx % save_every == 0:
-                save_estimator(
+                save_model(
                     state=trainable_state,
                     out_dir=out_dir,
-                    estimator=estimator,
-                    estimator_name=f"{estimator.__class__.__name__}-{episode_idx}",
+                    model=estimator,
+                    model_name=f"{estimator.__class__.__name__}-{episode_idx}",
                     sampler=env_state[0],
                 )
 

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -12,7 +12,7 @@ from synthpix.sampler import Sampler
 
 from eval import evaluate_batches
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
-from flowgym.make import save_estimator
+from flowgym.make import save_model
 from flowgym.training.caching import CacheManager, enrich_batch
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
@@ -391,12 +391,12 @@ def train_supervised(
                     batch_idx % save_every == 0 or batch_idx == num_batches - 1
                 ):
                     if not save_only_best:
-                        save_estimator(
+                        save_model(
                             state=trainable_state,
                             out_dir=out_dir,
                             step=batch_idx,
-                            estimator=estimator,
-                            estimator_name=estimator.__class__.__name__,
+                            model=estimator,
+                            model_name=estimator.__class__.__name__,
                             sampler=sampler,
                         )
 
@@ -414,12 +414,12 @@ def train_supervised(
                         if current_mean_error < best_mean_error:
                             best_mean_error = current_mean_error
 
-                            save_estimator(
+                            save_model(
                                 state=trainable_state,
                                 out_dir=out_dir,
                                 step=batch_idx,
-                                estimator=estimator,
-                                estimator_name=estimator.__class__.__name__,
+                                model=estimator,
+                                model_name=estimator.__class__.__name__,
                                 sampler=sampler,
                             )
 

--- a/tests/integration/caching/test_integration.py
+++ b/tests/integration/caching/test_integration.py
@@ -47,7 +47,7 @@ def mock_sampler(num_batches, keys_list):
         yield MockBatch(batch_size=len(keys), keys=keys)
 
 
-@patch("src.train_supervised.save_estimator")
+@patch("src.train_supervised.save_model")
 def test_train_supervised_caching_integration(mock_save_estimator):
     """Misses are computed and cached; a second pass is all hits."""
 
@@ -162,7 +162,7 @@ def test_train_supervised_caching_integration(mock_save_estimator):
         assert payload_5["values"][0, 0] == 5.0
 
 
-@patch("src.train_supervised.save_estimator")
+@patch("src.train_supervised.save_model")
 def test_estimator_enrich(mock_save_estimator):
     """Estimator.enrich is called for missing keys and the result persisted."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/integration/caching/test_raft_integration.py
+++ b/tests/integration/caching/test_raft_integration.py
@@ -33,7 +33,7 @@ class MiniRaftBatch:
         return self
 
 
-@patch("src.train_supervised.save_estimator")
+@patch("src.train_supervised.save_model")
 def test_raft_integration_caching(mock_save_estimator):
     """RAFT populates the cache on first pass; second pass serves hits only."""
 

--- a/tests/integration/training/test_full_integration.py
+++ b/tests/integration/training/test_full_integration.py
@@ -24,13 +24,13 @@ from train_supervised import train_supervised
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _mock_save_estimator(
-    state, out_dir, step=None, estimator=None, estimator_name=None, **kwargs
+def _mock_save_model(
+    state, out_dir, step=None, model=None, model_name=None, **kwargs
 ):
-    """Mock save_estimator: make checkpoint dirs without writing."""
+    """Mock save_model: make checkpoint dirs without writing."""
     out_dir = Path(out_dir)
-    if estimator_name:
-        ckpt_dir = out_dir / "checkpoints" / estimator_name
+    if model_name:
+        ckpt_dir = out_dir / "checkpoints" / model_name
     else:
         ckpt_dir = out_dir / "checkpoints"
     ckpt_dir.mkdir(parents=True, exist_ok=True)
@@ -72,12 +72,12 @@ def test_train_supervised_full_integration(
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    # Mock both evaluate_batches and save_estimator
+    # Mock both evaluate_batches and save_model
     with (
         patch("train_supervised.evaluate_batches") as mock_eval,
         patch(
-            "train_supervised.save_estimator",
-            side_effect=_mock_save_estimator,
+            "train_supervised.save_model",
+            side_effect=_mock_save_model,
         ),
     ):
         mock_eval.return_value = {
@@ -175,7 +175,7 @@ def test_train_supervised_replay_enrichment(
 def test_train_supervised_checkpointing_roundtrip(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """save_estimator is called at the configured save_every interval."""
+    """save_model is called at the configured save_every interval."""
     estimator = DummyEstimator(train_type="supervised")
 
     def create_state_fn(img, key):
@@ -195,10 +195,10 @@ def test_train_supervised_checkpointing_roundtrip(
 
     def tracking_save(*args, **kwargs):
         save_calls.append((args, kwargs))
-        return _mock_save_estimator(*args, **kwargs)
+        return _mock_save_model(*args, **kwargs)
 
     # Run training to create a checkpoint
-    with patch("train_supervised.save_estimator", side_effect=tracking_save):
+    with patch("train_supervised.save_model", side_effect=tracking_save):
         train_supervised(
             estimator=estimator,
             estimator_config={"config": {"jit": False}},
@@ -212,8 +212,8 @@ def test_train_supervised_checkpointing_roundtrip(
             key=jax.random.PRNGKey(42),
         )
 
-    # Verify save_estimator was called at expected intervals (batch 3)
-    assert len(save_calls) >= 1, "Expected at least one save_estimator call"
+    # Verify save_model was called at expected intervals (batch 3)
+    assert len(save_calls) >= 1, "Expected at least one save_model call"
 
 
 def test_train_supervised_no_enrichment_without_flag(
@@ -298,9 +298,9 @@ def test_train_rl_full_integration(tmp_path, mock_env):
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    # Run training with mocked save_estimator
+    # Run training with mocked save_model
     with (
-        patch("train.save_estimator", side_effect=_mock_save_estimator),
+        patch("train.save_model", side_effect=_mock_save_model),
         patch("train.log_flow_estimate"),
     ):
         train(
@@ -539,11 +539,11 @@ def test_train_supervised_save_only_best(
 
     def tracking_save(*args, **kwargs):
         save_calls.append((args, kwargs))
-        return _mock_save_estimator(*args, **kwargs)
+        return _mock_save_model(*args, **kwargs)
 
     with (
         patch("train_supervised.evaluate_batches", side_effect=mock_evaluate),
-        patch("train_supervised.save_estimator", side_effect=tracking_save),
+        patch("train_supervised.save_model", side_effect=tracking_save),
     ):
         train_supervised(
             estimator=estimator,

--- a/tests/integration/training/test_integrated_checkpointing.py
+++ b/tests/integration/training/test_integrated_checkpointing.py
@@ -1,6 +1,6 @@
 """Integration tests for the save/load checkpointing pipeline with synthpix.
 
-Verifies that save_estimator and load_estimator round-trip state correctly
+Verifies that save_model and load_model round-trip state correctly
 when paired with a real Grain-backed SyntheticImageSampler.
 """
 
@@ -13,7 +13,7 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_estimator, save_estimator
+from flowgym.make import load_model, save_model
 
 
 def test_real_integration_checkpointing(tmp_path):
@@ -90,12 +90,12 @@ def test_real_integration_checkpointing(tmp_path):
     )
 
     # 5. Save atomically
-    estimator_name = "IntegrationTest"
-    save_path_str = save_estimator(
+    model_name = "IntegrationTest"
+    save_path_str = save_model(
         state=state,
         out_dir=tmp_path,
         step=10,
-        estimator_name=estimator_name,
+        model_name=model_name,
         sampler=sampler,
     )
     save_path = pathlib.Path(save_path_str)
@@ -134,11 +134,11 @@ def test_real_integration_checkpointing(tmp_path):
         )
         print(f"  Batch {i}: ✓ identical")
 
-    # 8. Restore estimator via load_estimator (partial restore)
+    # 8. Restore estimator via load_model (partial restore)
     template_state = NNEstimatorTrainableState.create(
         apply_fn=apply_fn, params=params, tx=tx
     )
-    restored_estimator = load_estimator(
+    restored_estimator = load_model(
         save_path, template_state, mode="resume"
     )
     assert restored_estimator.step == 10

--- a/tests/integration/training/test_trainable_state_integration.py
+++ b/tests/integration/training/test_trainable_state_integration.py
@@ -18,8 +18,8 @@ from flowgym.common.base.trainable_state import (
     NNEstimatorTrainableState,
 )
 from flowgym.make import (
-    load_estimator,
-    save_estimator,
+    load_model,
+    save_model,
 )
 
 # ---------------------------------------------------------------------------
@@ -176,32 +176,32 @@ def test_apply_gradients_updates_params_and_preserves_tx_and_extras():
 
 
 # ---------------------------------------------------------------------------
-# save_estimator / load_estimator: resumability and module-name independence
+# save_model / load_model: resumability and module-name independence
 # ---------------------------------------------------------------------------
 
 
 def test_save_and_load_roundtrip_resumable(tmp_path):
-    """save_estimator/load_estimator round-trip preserves all dynamic state."""
+    """save_model/load_model round-trip preserves all dynamic state."""
 
     out_dir = tmp_path
-    estimator_name = "dummy_estimator"
-    ckpt_path = out_dir / "checkpoints" / estimator_name
+    model_name = "dummy_estimator"
+    ckpt_path = out_dir / "checkpoints" / model_name
 
     # Original state we want to resume later
     original_state = _make_dummy_state(global_step=7)
 
     # Save
-    save_estimator(
+    save_model(
         original_state,
         out_dir=str(out_dir),
-        estimator_name=estimator_name,
+        model_name=model_name,
     )
     assert ckpt_path.exists(), "Checkpoint directory should be created"
 
     # Build a fresh template_state (as if in a new process)
     template_state = _make_dummy_state(global_step=0)
 
-    loaded_state = load_estimator(str(ckpt_path), template_state, mode="resume")
+    loaded_state = load_model(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(loaded_state, NNEstimatorTrainableState)
 
@@ -214,8 +214,8 @@ def test_save_and_load_roundtrip_resumable(tmp_path):
 def test_save_and_load_supports_training_resumption(tmp_path):
     """Resumed training produces results identical to uninterrupted training."""
     out_dir = tmp_path
-    estimator_name = "resumable_estimator"
-    ckpt_path = out_dir / "checkpoints" / estimator_name
+    model_name = "resumable_estimator"
+    ckpt_path = out_dir / "checkpoints" / model_name
 
     # Initial state
     init_state = _make_dummy_state(global_step=0)
@@ -230,12 +230,12 @@ def test_save_and_load_supports_training_resumption(tmp_path):
 
     # Path B: train 1 step, save, load, train another step
     s1_b = init_state.apply_gradients(grads=grads1)
-    save_estimator(s1_b, out_dir=str(out_dir), estimator_name=estimator_name)
+    save_model(s1_b, out_dir=str(out_dir), model_name=model_name)
     assert ckpt_path.exists()
 
     # Fresh template to simulate new process
     template_state = _make_dummy_state(global_step=0)
-    s1_loaded = load_estimator(str(ckpt_path), template_state, mode="resume")
+    s1_loaded = load_model(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(s1_loaded, NNEstimatorTrainableState)
 
@@ -248,19 +248,19 @@ def test_save_and_load_supports_training_resumption(tmp_path):
 
 
 def test_load_estimator_uses_template_static_tx_not_checkpoint(tmp_path):
-    """load_estimator binds tx from the template, not from checkpoint data."""
+    """load_model binds tx from the template, not from checkpoint data."""
     out_dir = tmp_path
-    estimator_name = "dummy_estimator"
-    ckpt_path = out_dir / "checkpoints" / estimator_name
+    model_name = "dummy_estimator"
+    ckpt_path = out_dir / "checkpoints" / model_name
 
     # First state uses tx1 (e.g., Adam with lr=1e-3)
     tx1 = optax.adam(learning_rate=1e-3)
     original_state = _make_dummy_state(tx=tx1, global_step=10)
 
-    save_estimator(
+    save_model(
         original_state,
         out_dir=str(out_dir),
-        estimator_name=estimator_name,
+        model_name=model_name,
     )
     assert ckpt_path.exists()
 
@@ -268,7 +268,7 @@ def test_load_estimator_uses_template_static_tx_not_checkpoint(tmp_path):
     tx2 = optax.adam(learning_rate=5e-4)
     template_state = _make_dummy_state(tx=tx2, global_step=0)
 
-    loaded_state = load_estimator(str(ckpt_path), template_state, mode="resume")
+    loaded_state = load_model(str(ckpt_path), template_state, mode="resume")
 
     assert isinstance(loaded_state, NNEstimatorTrainableState)
 
@@ -283,24 +283,24 @@ def test_load_estimator_uses_template_static_tx_not_checkpoint(tmp_path):
 
 
 def test_save_estimator_turns_relative_directory_into_absolute(tmp_path):
-    """save_estimator resolves a relative out_dir to an absolute path."""
+    """save_model resolves a relative out_dir to an absolute path."""
     relative_out_dir = "relative_dir"
-    estimator_name = "test_estimator"
-    # Expected: relative_out_dir/checkpoints/estimator_name/step_0...
-    # save_estimator places it in relative_out_dir/checkpoints/<name>
-    # Return value of save_estimator is the full step path.
+    model_name = "test_estimator"
+    # Expected: relative_out_dir/checkpoints/model_name/step_0...
+    # save_model places it in relative_out_dir/checkpoints/<name>
+    # Return value of save_model is the full step path.
     # Test checks if directory exists.
     ckpt_path = os.path.abspath(
-        os.path.join(relative_out_dir, "checkpoints", estimator_name)
+        os.path.join(relative_out_dir, "checkpoints", model_name)
     )
 
     state = _make_dummy_state(global_step=0)
 
     # Save using relative path
-    save_estimator(
+    save_model(
         state,
         out_dir=relative_out_dir,
-        estimator_name=estimator_name,
+        model_name=model_name,
     )
 
     # Check that the checkpoint directory was created at the absolute path

--- a/tests/mocks/training.py
+++ b/tests/mocks/training.py
@@ -68,7 +68,7 @@ def mock_sampler():
     sampler.__iter__.return_value = iter([batch] * 10)
     sampler.shutdown = MagicMock()
     sampler.reset = MagicMock()
-    # Set grain_iterator to None so save_estimator skips sampler serialization
+    # Set grain_iterator to None so save_model skips sampler serialization
     sampler.grain_iterator = None
     return sampler
 

--- a/tests/unit/common/test_preprocess_config.py
+++ b/tests/unit/common/test_preprocess_config.py
@@ -22,7 +22,7 @@ from flowgym.common.preprocess import (
     resize_image,
     stretch_contrast,
 )
-from flowgym.make import compile_estimator
+from flowgym.make import compile_model
 from flowgym.utils import load_configuration
 
 config = load_configuration("src/flowgym/config/testing.yaml")
@@ -138,7 +138,7 @@ def test_preprocess_config(B, N, seed):
     # Instantiate the dummy estimator
     estimator = DummyEstimator.from_config(pre_processing_config)
     trainable_state = estimator.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_estimator(
+    create_state_fn, compute_estimate_fn = compile_model(
         estimator, processed_image_reference, False
     )
     # Create the state
@@ -217,7 +217,7 @@ def test_preprocess_jit(B, H, time_limit, seed):
     # Instantiate the dummy estimator
     estimator = DummyEstimator.from_config(pre_processing_config)
     trainable_state = estimator.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_estimator(
+    create_state_fn, compute_estimate_fn = compile_model(
         estimator, image, True
     )
     # Warm up

--- a/tests/unit/flow/test_postprocess_config.py
+++ b/tests/unit/flow/test_postprocess_config.py
@@ -28,7 +28,7 @@ from flowgym.flow.postprocess import (
     tile_average_interpolation,
     universal_median_test,
 )
-from flowgym.make import compile_estimator
+from flowgym.make import compile_model
 from flowgym.utils import load_configuration
 
 config = load_configuration("src/flowgym/config/testing.yaml")
@@ -182,7 +182,7 @@ def test_postprocess_config(B, N, seed):
     # Instantiate the dummy estimator
     estimator = DummyEstimator.from_config(post_process_config)
     trainable_state = estimator.create_trainable_state(image, key)
-    create_state_fn, compute_estimate_fn = compile_estimator(
+    create_state_fn, compute_estimate_fn = compile_model(
         estimator, flow_reference, False
     )
     # Create the state
@@ -271,7 +271,7 @@ def test_postprocess_jit(B, H, time_limit, seed):
     # Instantiate the dummy estimator
     estimator = DummyEstimator.from_config(post_process_config)
     trainable_state = estimator.create_trainable_state(image, key=key)
-    create_state_fn, compute_estimate_fn = compile_estimator(
+    create_state_fn, compute_estimate_fn = compile_model(
         estimator, jnp.zeros((*image.shape, 2)), True
     )
     # Warm up

--- a/tests/unit/training/test_checkpointing.py
+++ b/tests/unit/training/test_checkpointing.py
@@ -16,7 +16,7 @@ from flax.core import FrozenDict
 
 from flowgym.common.base.estimator import Estimator
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_estimator, make_manager, save_estimator
+from flowgym.make import load_model, make_manager, save_model
 from flowgym.training.optimizer import build_optimizer_from_config
 
 # ---------------------------------------------------------------------------
@@ -100,14 +100,14 @@ def test_checkpoint_resume_roundtrip(clean_tmp_path):
     )
     state1 = state0.apply_gradients(grads=grads1)  # step should be 1
     step_to_save = int(state1.step)
-    estimator_name = "DummyEstimator"
+    model_name = "DummyEstimator"
 
     # Save checkpoint
-    ckpt_dir = save_estimator(
+    ckpt_dir = save_model(
         state=state1,
         out_dir=tmp_path,
         step=step_to_save,
-        estimator_name=estimator_name,
+        model_name=model_name,
     )
 
     ckpt_dir = Path(ckpt_dir)
@@ -134,7 +134,7 @@ def test_checkpoint_resume_roundtrip(clean_tmp_path):
     )
 
     # Restore from checkpoint
-    restored_state = load_estimator(
+    restored_state = load_model(
         ckpt_dir=ckpt_dir,
         template_state=template_state,
         mode="resume",
@@ -189,16 +189,16 @@ def test_checkpoint_finetune_with_new_optimizer(clean_tmp_path):
     )
     trained_state = state0.apply_gradients(grads=grads)
     step_to_save = int(trained_state.step)
-    estimator_name = "DummyEstimator"
+    model_name = "DummyEstimator"
 
     # Save checkpoint
-    save_estimator(
+    save_model(
         state=trained_state,
         out_dir=tmp_path,
         step=step_to_save,
-        estimator_name=estimator_name,
+        model_name=model_name,
     )
-    ckpt_dir = tmp_path / "checkpoints" / estimator_name / str(step_to_save)
+    ckpt_dir = tmp_path / "checkpoints" / model_name / str(step_to_save)
     time.sleep(1)
     assert ckpt_dir.exists()
 
@@ -212,7 +212,7 @@ def test_checkpoint_finetune_with_new_optimizer(clean_tmp_path):
     )
 
     # Load only parameters from checkpoint
-    restored_state = load_estimator(
+    restored_state = load_model(
         ckpt_dir=ckpt_dir,
         template_state=template_state,
         mode="params_only",
@@ -274,7 +274,7 @@ def test_finetune_from_params_only_checkpoint_structure_mismatch(
         )
         mngr.wait_until_finished()
 
-    # We pass the ROOT to load_estimator so it finds step 0
+    # We pass the ROOT to load_model so it finds step 0
     ckpt_to_load = ckpt_root
 
     # 3) Build a full trainable-state template (params + opt_state + extras)
@@ -289,7 +289,7 @@ def test_finetune_from_params_only_checkpoint_structure_mismatch(
     # 4) Try to fine-tune: mode='params_only' but template_state is a full
     #    NNEstimatorTrainableState. With partial_restore=True, this now SUCCEEDS
     #    and restores what it can (params).
-    restored_state = load_estimator(
+    restored_state = load_model(
         ckpt_dir=ckpt_to_load,
         template_state=template_state,
         mode="params_only",
@@ -325,7 +325,7 @@ def test_finetune_from_params_only_checkpoint_works(clean_tmp_path):
     )
 
     # 4) Fine-tune: mode='params_only' should now succeed and give us params
-    restored_state = load_estimator(
+    restored_state = load_model(
         ckpt_dir=ckpt_root,
         template_state=template_state,
         mode="params_only",
@@ -358,11 +358,11 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
         apply_fn=simple_apply_fn, params=params, tx=tx_adam, extras=None
     )
 
-    save_estimator(
+    save_model(
         state=state_save,
         out_dir=tmp_path,
-        estimator=estimator_adam,
-        estimator_name="RobustTest",
+        model=estimator_adam,
+        model_name="RobustTest",
         step=1,
     )
     ckpt_dir = tmp_path / "checkpoints" / "RobustTest" / "1"
@@ -387,7 +387,7 @@ def test_checkpoint_robust_optimizer_override(clean_tmp_path):
     assert leaves_ema > leaves_adam, "EMA should have more leaves"
 
     # 3) Restore should override EMA with Adam from checkpoint
-    restored = load_estimator(
+    restored = load_model(
         ckpt_dir=ckpt_dir, template_state=template_ema, mode="resume"
     )
 

--- a/tests/unit/training/test_partial_checkpointing.py
+++ b/tests/unit/training/test_partial_checkpointing.py
@@ -14,7 +14,7 @@ import synthpix
 from flax.core import FrozenDict
 
 from flowgym.common.base.trainable_state import NNEstimatorTrainableState
-from flowgym.make import load_estimator, save_estimator
+from flowgym.make import load_model, save_model
 
 
 def _make_synthetic_config(file_list: list[str]) -> dict:
@@ -147,13 +147,13 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
 
         # 3. Create estimator state and save checkpoint
         estimator_state = _make_estimator_state()
-        estimator_name = "CheckpointTest_synthetic"
+        model_name = "CheckpointTest_synthetic"
 
-        save_path_str = save_estimator(
+        save_path_str = save_model(
             state=estimator_state,
             out_dir=tmp_path,
             step=10,
-            estimator_name=estimator_name,
+            model_name=model_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)
@@ -183,7 +183,7 @@ def test_synthetic_sampler_checkpoint_integration(tmp_path, npy_flow_files):
 
         # 9. Verify estimator state can also be restored independently
         template_state = _make_estimator_state()
-        restored_estimator = load_estimator(
+        restored_estimator = load_model(
             save_path, template_state, mode="resume"
         )
         assert restored_estimator.step == 10, "step should be restored"
@@ -216,13 +216,13 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
 
         # 3. Create estimator state and save checkpoint
         estimator_state = _make_estimator_state()
-        estimator_name = "CheckpointTest_real"
+        model_name = "CheckpointTest_real"
 
-        save_path_str = save_estimator(
+        save_path_str = save_model(
             state=estimator_state,
             out_dir=tmp_path,
             step=10,
-            estimator_name=estimator_name,
+            model_name=model_name,
             sampler=sampler,
         )
         save_path = pathlib.Path(save_path_str)
@@ -252,7 +252,7 @@ def test_real_sampler_checkpoint_integration(tmp_path, mock_mat_files):
 
         # 9. Verify estimator state can also be restored independently
         template_state = _make_estimator_state()
-        restored_estimator = load_estimator(
+        restored_estimator = load_model(
             save_path, template_state, mode="resume"
         )
         assert restored_estimator.step == 10, "step should be restored"

--- a/tests/unit/training/test_sampler_checkpointing.py
+++ b/tests/unit/training/test_sampler_checkpointing.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import orbax.checkpoint as ocp
 
 from flowgym.environment.fluid_env import FluidEnv
-from flowgym.make import save_estimator
+from flowgym.make import save_model
 
 
 class DummyState:
@@ -46,7 +46,7 @@ class MockManager:
 
 
 def test_save_estimator_is_atomic(monkeypatch):
-    """save_estimator writes state, sampler, and grain in one manager call."""
+    """save_model writes state, sampler, and grain in one manager call."""
     manager_instances = []
 
     def mock_init(ckpt_dir, options=None):
@@ -67,12 +67,12 @@ def test_save_estimator_is_atomic(monkeypatch):
 
     out_dir = "/tmp/test_ckpt"
 
-    save_estimator(
+    save_model(
         state=state,
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        estimator_name="TestEstimator",
+        model_name="TestEstimator",
     )
 
     assert len(manager_instances) == 1
@@ -113,12 +113,12 @@ def test_save_estimator_skips_non_grain_sampler(monkeypatch):
 
     out_dir = "/tmp/test_ckpt_no_grain"
 
-    save_estimator(
+    save_model(
         state=state,
         out_dir=out_dir,
         step=10,
         sampler=sampler,
-        estimator_name="TestEstimatorNoGrain",
+        model_name="TestEstimatorNoGrain",
     )
 
     mngr = manager_instances[0]


### PR DESCRIPTION
## Summary
Renames the public `make.py` API to match the private `fluids-estimation` dev repo, so subsequent cross-repo ports (checkpointing, experiments) apply cleanly on a matching API surface:

- `compile_estimator` → `compile_model`
- `save_estimator` → `save_model`
- `load_estimator` → `load_model`
- their `estimator` parameter → `model`, and `estimator_name` → `model_name`

All call sites and the `save_model` test mock are updated. **Pure rename, no behavioural change** (132 insertions / 132 deletions).

Intentionally left unchanged (matching private): the `Estimator` class, `*EstimatorTrainableState`, `make_estimator`, the `estimators/` config dir, and `estimator:` config keys.

## Test plan
- [x] Collection clean: 1004 tests collected, no import errors
- [x] `pytest tests/unit/training/test_checkpointing.py` (5 passed) — exercises `save_model`/`load_model`
- [x] `pytest tests/unit/training/test_sampler_checkpointing.py tests/unit/training/test_partial_checkpointing.py` (5 passed)
- [x] `pytest tests/unit/flow/test_postprocess_config.py tests/unit/common/test_preprocess_config.py` — exercise `compile_model` (passed; CPU-heavy)