### PR TITLE
feat(checkpoint): long-lived Checkpointer + W&B upload + wandb-resume

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["tests*", "docs*"]
 # Dependency groups
 [dependency-groups]
 dev = [
-    "synthpix>=0.2.0",
+    "synthpix @ git+https://github.com/antonioterpin/synthpix.git@8cfbd7d",
     "pre-commit==4.0.1",
     "snowballstemmer",
     "pytest==7.4.4",
@@ -62,7 +62,7 @@ dev = [
 ]
 
 synthpix-cuda12 = [
-    "synthpix[cuda12]>=0.2.0",
+    "synthpix[cuda12] @ git+https://github.com/antonioterpin/synthpix.git@8cfbd7d",
 ]
 
 dev-cuda12 = [

--- a/src/flowgym/_synthpix_compat.py
+++ b/src/flowgym/_synthpix_compat.py
@@ -1,0 +1,114 @@
+"""Compatibility shim for synthpix sampler restore.
+
+synthpix's :class:`SyntheticImageSampler.restore_state` substitutes a
+``jax.ShapeDtypeStruct((np.nan,), jnp.uint8)`` template placeholder for
+the ``files_scheduler`` field whenever the underlying scheduler state
+was ``None`` at save time. The intent is "unknown dim — let orbax read
+the real shape from disk metadata".
+
+orbax 0.11+ rejects NaN-valued shape entries during deserialization with
+``TypeError: 'float' object cannot be interpreted as an integer`` at
+``orbax/checkpoint/_src/arrays/numpy_utils.py:53: slice(*x.indices(n))``.
+The intended "use the saved shape" semantics is already what orbax does
+for ``None`` template leaves, so we patch ``restore_state`` to replace
+NaN-shape placeholders with ``None``.
+
+The shim is idempotent and a no-op when synthpix is not installed.
+Tracked upstream at synthpix `src/synthpix/sampler/synthetic.py` (the
+``np.nan`` sentinel is still on `main`); remove this shim once a
+synthpix release drops the NaN placeholder.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INSTALLED_ATTR = "_flowgym_nan_shape_shim"
+
+
+def _has_nan_shape(value: Any) -> bool:
+    """Detect a ShapeDtypeStruct whose shape contains a NaN dimension.
+
+    Args:
+        value: Any object; only ``jax.ShapeDtypeStruct`` instances are
+            inspected, every other type returns ``False``.
+
+    Returns:
+        ``True`` iff ``value`` is a ``jax.ShapeDtypeStruct`` and at
+        least one entry of its ``shape`` tuple is a NaN float.
+    """
+    import jax  # noqa: PLC0415
+    import numpy as np  # noqa: PLC0415
+
+    if not isinstance(value, jax.ShapeDtypeStruct):
+        return False
+    return any(isinstance(d, float) and np.isnan(d) for d in value.shape)
+
+
+def _scrub_nan_placeholders(state_dict: dict[str, Any]) -> dict[str, Any]:
+    """Replace NaN-shape ShapeDtypeStruct leaves with ``None`` in-place.
+
+    Args:
+        state_dict: Mutable mapping returned by synthpix's
+            ``restore_state``. Entries with NaN-shape placeholders are
+            rewritten to ``None`` so orbax falls back to the on-disk
+            shape during restore.
+
+    Returns:
+        The same ``state_dict`` (mutated), for ergonomics.
+    """
+    for key, value in list(state_dict.items()):
+        if _has_nan_shape(value):
+            state_dict[key] = None
+    return state_dict
+
+
+def install_restore_state_shim() -> bool:
+    """Patch ``SyntheticImageSampler.restore_state`` to scrub NaN shapes.
+
+    No-ops when synthpix is not importable and is idempotent: a second
+    call on an already-patched class returns ``False``.
+
+    Returns:
+        ``True`` when a fresh patch was applied, ``False`` when synthpix
+        is missing or already patched.
+    """
+    try:
+        from synthpix.sampler.synthetic import (  # noqa: PLC0415
+            SyntheticImageSampler,
+        )
+    except ImportError:
+        return False
+
+    cls = SyntheticImageSampler
+    original_prop = cls.__dict__.get("restore_state")
+    if not isinstance(original_prop, property) or original_prop.fget is None:
+        # synthpix layout changed; surface but do not raise so flowgym
+        # imports do not break on unexpected sampler versions.
+        logger.debug(
+            "synthpix.SyntheticImageSampler.restore_state is not a "
+            "readable property; skipping NaN-shape compat shim."
+        )
+        return False
+    original_fget = original_prop.fget
+    if getattr(original_fget, _INSTALLED_ATTR, False):
+        return False
+
+    def restore_state(self: Any) -> dict[str, Any]:
+        return _scrub_nan_placeholders(original_fget(self))
+
+    setattr(restore_state, _INSTALLED_ATTR, True)
+    restore_state.__doc__ = original_fget.__doc__
+    # Replacing the class-level property at runtime: synthpix's
+    # ``restore_state`` upstream has no setter, so basedpyright flags
+    # the attribute assignment. We're intentionally swapping the
+    # property descriptor on the class object itself — a class-attribute
+    # write, not an instance-attribute write — which is the standard
+    # monkey-patch idiom. Targeted ignore documents the reason.
+    cls.restore_state = property(  # pyright: ignore[reportAttributeAccessIssue]
+        restore_state
+    )
+    return True

--- a/src/flowgym/checkpoint_source.py
+++ b/src/flowgym/checkpoint_source.py
@@ -1,0 +1,197 @@
+"""Resolve checkpoint source strings into local filesystem paths.
+
+Two source forms are supported:
+
+1. A plain filesystem path (``str`` or :class:`pathlib.Path`). Returned
+   resolved to an absolute path, unchanged.
+
+2. A W&B artifact URI of the form ``wandb://<wandb-reference>[/<subpath>]``
+   where ``<wandb-reference>`` is anything ``wandb.use_artifact`` /
+   ``wandb.Api().artifact`` accept (e.g.
+   ``entity/project/name:alias`` or ``name:alias``). The artifact is
+   downloaded and the resolver returns the path to the optional
+   in-artifact subpath, or the download root if no subpath is given.
+
+The optional in-artifact subpath must follow an explicit ``:alias``
+segment so the boundary between the artifact reference and the subpath
+is unambiguous.
+
+Typical use::
+
+    from flowgym.checkpoint_source import resolve_checkpoint_source
+
+    path = resolve_checkpoint_source(load_from)
+    trained_state = load_model(path, template_state, mode="params_only")
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
+
+WANDB_URI_PREFIX = "wandb://"
+
+
+def is_wandb_uri(source: str | PathLike[str]) -> bool:
+    """Return True iff ``source`` looks like a W&B artifact URI.
+
+    Args:
+        source: Candidate source string.
+
+    Returns:
+        Whether ``source`` starts with the ``wandb://`` scheme prefix.
+    """
+    return str(source).startswith(WANDB_URI_PREFIX)
+
+
+def parse_wandb_uri(uri: str) -> tuple[str, str]:
+    """Split a ``wandb://`` URI into (wandb-reference, in-artifact subpath).
+
+    Examples::
+
+        parse_wandb_uri("wandb://entity/project/name:alias/jax/checkpoints/0")
+        # -> ("entity/project/name:alias", "jax/checkpoints/0")
+
+        parse_wandb_uri("wandb://entity/project/name:alias")
+        # -> ("entity/project/name:alias", "")
+
+        parse_wandb_uri("wandb://entity/project/name")
+        # -> ("entity/project/name", "")   # wandb defaults the alias
+
+    Args:
+        uri: URI string starting with the ``wandb://`` prefix.
+
+    Returns:
+        A ``(wandb_reference, subpath)`` pair. ``subpath`` is ``""``
+        when no in-artifact subpath was specified.
+
+    Raises:
+        ValueError: If the URI does not have the ``wandb://`` prefix,
+            or if a subpath was given without an explicit ``:alias``
+            anchor (which would make the boundary between artifact
+            reference and subpath ambiguous).
+    """
+    if not is_wandb_uri(uri):
+        raise ValueError(f"Expected a {WANDB_URI_PREFIX!r} URI, got {uri!r}.")
+    body = uri[len(WANDB_URI_PREFIX) :]
+    if not body:
+        raise ValueError(
+            f"Empty {WANDB_URI_PREFIX} URI: expected an artifact "
+            f"reference after the scheme. Got: {uri!r}."
+        )
+    if ":" in body:
+        ref_head, after_alias = body.split(":", 1)
+        # Aliases are letters/digits/._- only, so the first ``/`` after
+        # the alias unambiguously starts the in-artifact subpath.
+        if "/" in after_alias:
+            alias, subpath = after_alias.split("/", 1)
+        else:
+            alias, subpath = after_alias, ""
+        if not ref_head or not alias:
+            raise ValueError(
+                f"Malformed {WANDB_URI_PREFIX} URI: the artifact "
+                "reference and the alias around ':' must both be "
+                f"non-empty. Got: {uri!r}."
+            )
+        wandb_ref = f"{ref_head}:{alias}"
+        return wandb_ref, subpath
+
+    # No explicit alias. We cannot disambiguate a trailing subpath from
+    # the artifact reference itself (which already contains ``/``
+    # separators between entity/project/name), so accept only the bare
+    # reference and reject any extra path-like content.
+    if body.count("/") <= 2:
+        return body, ""
+    raise ValueError(
+        f"Ambiguous {WANDB_URI_PREFIX} URI: a subpath is only allowed "
+        "after an explicit ':alias' segment. Got: "
+        f"{uri!r}."
+    )
+
+
+def resolve_checkpoint_source(
+    source: str | PathLike[str],
+    *,
+    download_dir: str | PathLike[str] | None = None,
+) -> Path:
+    """Resolve a checkpoint source string to a local filesystem path.
+
+    Args:
+        source: Either a filesystem path or a ``wandb://`` URI. See the
+            module docstring for the URI grammar.
+        download_dir: Optional override for where wandb materializes
+            the artifact files. When ``None``, wandb uses its default
+            cache location (typically ``./artifacts/<name>:<version>``).
+
+    Returns:
+        Absolute path to the requested checkpoint. For wandb URIs this
+        is ``<download_root>/<subpath>`` when a subpath was specified,
+        else ``<download_root>``.
+
+    Raises:
+        FileNotFoundError: When a wandb URI specifies an in-artifact
+            subpath that does not exist in the downloaded tree.
+        ImportError: When a wandb URI is given but the ``wandb``
+            package is not installed.
+        ValueError: When the in-artifact subpath is absolute or
+            otherwise escapes the artifact's download root (e.g. via
+            ``..`` segments).
+    """
+    if not is_wandb_uri(source):
+        return Path(source).resolve()
+
+    wandb_ref, subpath = parse_wandb_uri(str(source))
+
+    # Lazy import: wandb is an optional dependency in some environments,
+    # and we only need it for the URI path.
+    try:
+        import wandb  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError(
+            f"Resolving a {WANDB_URI_PREFIX} checkpoint source requires "
+            "the wandb package. Install it (e.g. `uv add wandb` or "
+            "`pip install wandb`) or pass a local filesystem path "
+            "instead."
+        ) from exc
+
+    run = getattr(wandb, "run", None)
+    if run is not None:
+        # Recording the load as a run input populates the wandb UI's
+        # data-lineage graph for free.
+        artifact = run.use_artifact(wandb_ref)
+    else:
+        artifact = wandb.Api().artifact(wandb_ref)
+
+    if download_dir is None:
+        download_root = Path(artifact.download()).resolve()
+    else:
+        download_root = Path(
+            artifact.download(root=str(download_dir))
+        ).resolve()
+
+    if not subpath:
+        return download_root
+
+    # Defend against absolute subpaths and ``..`` traversal: the
+    # subpath comes from a user-supplied URI and must stay strictly
+    # inside the artifact's download root.
+    if Path(subpath).is_absolute():
+        raise ValueError(
+            f"Subpath {subpath!r} must be relative to the artifact "
+            f"download root (got an absolute path)."
+        )
+    resolved = (download_root / subpath).resolve()
+    if not resolved.is_relative_to(download_root):
+        raise ValueError(
+            f"Subpath {subpath!r} escapes the artifact download root "
+            f"{download_root}."
+        )
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"Subpath {subpath!r} not found inside artifact downloaded "
+            f"from {wandb_ref!r} (looked in {download_root})."
+        )
+    return resolved

--- a/src/flowgym/checkpointing.py
+++ b/src/flowgym/checkpointing.py
@@ -1,0 +1,441 @@
+"""Checkpoint orchestration: orbax save, best-metric tracking, W&B upload."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Literal
+
+import goggles as gg
+import orbax.checkpoint as ocp
+
+from flowgym.make import build_save_args
+
+if TYPE_CHECKING:
+    from synthpix.sampler import Sampler
+
+    from flowgym.common.base import Estimator
+    from flowgym.common.base.trainable_state import NNEstimatorTrainableState
+
+logger = gg.get_logger(__name__, with_metrics=True)
+
+WandbUploadMode = Literal["never", "best", "every"]
+
+_VALID_UPLOAD_MODES = frozenset({"never", "best", "every"})
+
+
+@dataclass(frozen=True)
+class CheckpointConfig:
+    """Per-run checkpoint policy.
+
+    Attributes:
+        save_only_best: When True, ``save_periodic`` only saves if the
+            most recent validation produced a new best metric.
+        wandb_upload: Controls W&B uploads triggered from validation
+            events. ``"never"`` (default) skips uploads; ``"best"``
+            uploads only when a new best is observed (alias ``best``);
+            ``"every"`` uploads after every validation event (alias
+            ``latest``, plus ``best`` when applicable).
+        metric_key: Key into the validation metrics dict whose value
+            drives the best-metric comparison and is persisted to
+            orbax's per-step ``metrics`` so ``best_step`` survives a
+            process restart.
+        higher_is_better: When True, larger metric values are better.
+        keep: Maximum number of on-disk checkpoint steps to retain
+            (orbax ``max_to_keep``). The best step is exempt from
+            eviction (orbax preserves it alongside the most recent N).
+        artifact_type: W&B artifact type label.
+        artifact_name: W&B artifact name; defaults to
+            ``f"{model.__class__.__name__}_checkpoint"``.
+    """
+
+    save_only_best: bool = False
+    wandb_upload: WandbUploadMode = "never"
+    metric_key: str = "mean_error"
+    higher_is_better: bool = False
+    keep: int = 3
+    artifact_type: str = "checkpoint"
+    artifact_name: str | None = None
+
+    def __post_init__(self) -> None:
+        """Fail fast on typos or invalid values from YAML configs.
+
+        Raises:
+            ValueError: If any field carries an unsupported value (e.g.
+                ``wandb_upload="evrey"`` from a typo, or ``keep <= 0``).
+        """
+        if self.wandb_upload not in _VALID_UPLOAD_MODES:
+            raise ValueError(
+                f"CheckpointConfig.wandb_upload must be one of "
+                f"{sorted(_VALID_UPLOAD_MODES)}; got "
+                f"{self.wandb_upload!r}."
+            )
+        if not isinstance(self.keep, int) or self.keep < 1:
+            raise ValueError(
+                f"CheckpointConfig.keep must be a positive integer; "
+                f"got {self.keep!r}."
+            )
+        if not isinstance(self.metric_key, str) or not self.metric_key:
+            raise ValueError(
+                "CheckpointConfig.metric_key must be a non-empty string."
+            )
+
+    @classmethod
+    def from_configs(
+        cls, model_config: dict, dataset_config: dict
+    ) -> CheckpointConfig:
+        """Build a CheckpointConfig from the loaded run configs.
+
+        Reads ``model_config['checkpoint']`` (preferred) and falls back
+        to the legacy ``dataset_config['save_only_best']`` flag so
+        existing configs keep working unchanged.
+
+        Args:
+            model_config: Resolved model configuration.
+            dataset_config: Resolved dataset configuration.
+
+        Returns:
+            A CheckpointConfig ready to pass to ``train_supervised``.
+        """
+        spec = dict(model_config.get("checkpoint", {}) or {})
+        spec.setdefault(
+            "save_only_best", dataset_config.get("save_only_best", False)
+        )
+        return cls(**spec)
+
+
+class Checkpointer:
+    """Orchestrate orbax checkpoint saves and optional W&B uploads.
+
+    Owns **one** ``ocp.CheckpointManager`` for the lifetime of the
+    training run, rooted at ``out_dir/checkpoints/``. Best-step
+    tracking is delegated entirely to orbax via ``CheckpointManager
+    Options.best_fn`` — orbax persists per-step ``metrics`` on disk so
+    ``best_step`` survives a process restart without our own sidecar.
+
+    Saves are async by default; the long-lived manager keeps an orbax
+    background thread alive across calls. Callers must invoke
+    ``close()`` (or use the instance as a context manager) so the
+    in-flight save drains cleanly; without it the last save can be
+    lost and orbax's background commit can run into a torn-down
+    thread pool at interpreter exit.
+    """
+
+    def __init__(
+        self,
+        out_dir: str | Path,
+        model: Estimator,
+        sampler: Sampler | None = None,
+        config: CheckpointConfig | None = None,
+    ) -> None:
+        """Create the checkpointer and open a long-lived manager.
+
+        Args:
+            out_dir: Root output directory for the run; checkpoints land
+                under ``out_dir/checkpoints/<step>/``.
+            model: The estimator instance whose state is being saved.
+                Used to extract the optimizer config and to derive the
+                default W&B artifact name.
+            sampler: Optional synthpix sampler whose grain state is
+                serialized alongside the model state for exact resume.
+            config: Checkpoint policy; defaults to ``CheckpointConfig()``
+                (no upload, every-step periodic saves, ``mean_error``
+                as the best-metric key).
+        """
+        self._cfg = config or CheckpointConfig()
+        self._model = model
+        self._sampler = sampler
+        self._ckpt_root = Path(out_dir).resolve() / "checkpoints"
+        self._ckpt_root.mkdir(parents=True, exist_ok=True)
+
+        metric_key = self._cfg.metric_key
+        higher_is_better = self._cfg.higher_is_better
+
+        def _best_fn(metrics: Mapping[str, Any]) -> float:
+            try:
+                return float(metrics[metric_key])
+            except (KeyError, TypeError, ValueError):
+                return float("-inf" if higher_is_better else "inf")
+
+        options = ocp.CheckpointManagerOptions(
+            max_to_keep=self._cfg.keep,
+            best_fn=_best_fn,
+            best_mode="max" if higher_is_better else "min",
+            create=True,
+            enable_async_checkpointing=True,
+        )
+        self._mngr = ocp.CheckpointManager(self._ckpt_root, options=options)
+
+        self._artifact_name = (
+            self._cfg.artifact_name or f"{type(model).__name__}_checkpoint"
+        )
+        # Local best-metric tracker. Authoritative for the
+        # "is this a new best?" comparison in every mode — including
+        # ``wandb_upload="never"``, where validation metrics are
+        # observed but no save (and therefore no orbax metrics) happens
+        # until the next periodic event. Bootstrap from any persisted
+        # best so resumes pick up where they left off.
+        self._seen_best: float | None = None
+        seeded = self._mngr.best_step()
+        if seeded is not None:
+            recorded = self._mngr.metrics(seeded)
+            if recorded is not None:
+                try:
+                    self._seen_best = float(recorded[metric_key])
+                except (KeyError, TypeError, ValueError):
+                    pass
+        # Metrics from the most recent validation event. Passed to
+        # orbax on the next ``save_periodic`` so the on-disk best
+        # tracker stays consistent with the observed best even when
+        # the save is deferred to a periodic event.
+        self._last_observed: dict[str, float] = {}
+        # Latch consumed by ``save_periodic`` when ``save_only_best``
+        # is set: ``on_validation`` flips it on a real improvement; the
+        # next periodic save consumes it.
+        self._has_unsaved_best = False
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def best_step(self) -> int | None:
+        """Step of the best checkpoint seen so far (queries orbax)."""
+        return self._mngr.best_step()
+
+    @property
+    def best_metric(self) -> float | None:
+        """Best metric value seen so far across all validations.
+
+        May be more recent than ``best_step`` when validations happen
+        without an accompanying save (the typical
+        ``wandb_upload="never"`` + ``save_only_best=True`` shape).
+        """
+        return self._seen_best
+
+    def on_validation(
+        self,
+        state: NNEstimatorTrainableState,
+        step: int,
+        val_metrics: Mapping[str, Any],
+    ) -> str | None:
+        """Record a validation event and act per ``wandb_upload`` mode.
+
+        Args:
+            state: The trainable state to checkpoint, if needed.
+            step: Training step at which validation ran.
+            val_metrics: Validation metrics produced by
+                ``evaluate_batches``.
+
+        Returns:
+            The on-disk checkpoint directory path when a save happened,
+            ``None`` when validation was purely observational (no
+            extractable metric, or current mode does not save at
+            validation time).
+        """
+        metric_value = self._extract_metric(val_metrics)
+        if metric_value is None:
+            return None
+        is_new_best = self._is_better(metric_value)
+        self._last_observed = {self._cfg.metric_key: metric_value}
+        if is_new_best:
+            self._seen_best = metric_value
+            self._has_unsaved_best = True
+        mode = self._cfg.wandb_upload
+
+        will_save = mode == "every" or (mode == "best" and is_new_best)
+        if not will_save:
+            return None
+
+        path = self._save(state, step, self._last_observed)
+        if path is None:
+            return None
+        self._has_unsaved_best = False
+        # Orbax may have moved the best step now; re-confirm.
+        is_best_now = self._mngr.best_step() == step
+        aliases = ["best"] if is_best_now else ["latest"]
+        if is_best_now and mode == "every":
+            aliases.append("latest")
+        # Saves run async (``enable_async_checkpointing=True``), so
+        # ``self._mngr.save`` returns before the ``<step>/`` directory is
+        # finalized — only the ``<step>.orbax-checkpoint-tmp-*`` staging
+        # dir exists until orbax's background thread commits. W&B
+        # snapshots ``path`` eagerly via ``logger.artifact``; without a
+        # barrier here we would upload an incomplete or not-yet-present
+        # directory. Flush before handing the path on.
+        self._mngr.wait_until_finished()
+        self._upload(path, step, aliases=aliases)
+        return path
+
+    def save_periodic(
+        self, state: NNEstimatorTrainableState, step: int
+    ) -> str | None:
+        """Disk-only save at a periodic ``save_every`` event.
+
+        Honors ``save_only_best``: skips when no unsaved improvement is
+        pending. Does not upload (W&B uploads are tied to validation
+        events via ``on_validation``).
+
+        Args:
+            state: The trainable state to checkpoint.
+            step: Current training step.
+
+        Returns:
+            The on-disk checkpoint path when a save happened, otherwise
+            ``None``.
+        """
+        if self._cfg.save_only_best and not self._has_unsaved_best:
+            return None
+        # Same-step guard: when ``val_interval == save_every`` (a common
+        # 100/100 shape), ``on_validation`` may have already saved this
+        # exact step. Orbax would silently reject the duplicate write
+        # and our wrapper would log a WARNING every coincident
+        # interval. Skip the no-op here instead of generating noise.
+        latest = self._mngr.latest_step()
+        if latest is not None and step <= latest:
+            return None
+        self._has_unsaved_best = False
+        return self._save(state, step, self._last_observed or None)
+
+    def save_final(
+        self,
+        state: NNEstimatorTrainableState,
+        step: int,
+        val_metrics: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        """End-of-training save. Always writes to disk.
+
+        Uploads to W&B with the ``final`` alias when ``wandb_upload``
+        is not ``"never"`` so post-mortem analyses always have an
+        end-of-run snapshot to download from the run page.
+
+        When ``val_metrics`` is provided, the configured ``metric_key``
+        is extracted and handed to orbax so a best-on-final-validation
+        outcome correctly migrates ``best_step`` to the final
+        checkpoint (otherwise the ``best`` alias would stay on the
+        previous best even when the final eval is the genuine best).
+
+        Args:
+            state: The final trainable state to checkpoint.
+            step: Final training step.
+            val_metrics: Validation metrics from the final evaluation,
+                if available. ``None`` falls back to the most recent
+                observed validation metrics.
+
+        Returns:
+            The on-disk checkpoint path, or ``None`` when orbax rejected
+            the save (duplicate step / backward step).
+        """
+        metrics: Mapping[str, float] | None
+        if val_metrics is not None:
+            metric_value = self._extract_metric(val_metrics)
+            if metric_value is not None:
+                metrics = {self._cfg.metric_key: metric_value}
+                # Keep the in-memory tracker in sync so a subsequent
+                # query of ``best_metric`` reports the latest.
+                if self._is_better(metric_value):
+                    self._seen_best = metric_value
+            else:
+                metrics = self._last_observed or None
+        else:
+            metrics = self._last_observed or None
+        path = self._save(state, step, metrics)
+        if path is None:
+            return None
+        if self._cfg.wandb_upload != "never":
+            # See ``on_validation``: async saves must finalize before
+            # W&B snapshots the directory.
+            self._mngr.wait_until_finished()
+            self._upload(path, step, aliases=["final"])
+        return path
+
+    def close(self) -> None:
+        """Flush async saves and tear down the manager.
+
+        Idempotent. **Must** be called before the process exits or the
+        last in-flight save can be lost and the interpreter can raise
+        on shutdown (orbax tries to schedule work onto a dying thread
+        pool). Use the Checkpointer as a context manager to make this
+        automatic.
+        """
+        if self._closed:
+            return
+        try:
+            self._mngr.wait_until_finished()
+        finally:
+            self._mngr.close()
+            self._closed = True
+
+    def __enter__(self) -> Checkpointer:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _save(
+        self,
+        state: NNEstimatorTrainableState,
+        step: int,
+        metrics: Mapping[str, float] | None,
+    ) -> str | None:
+        args = build_save_args(
+            state, step, model=self._model, sampler=self._sampler
+        )
+        saved = self._mngr.save(step=step, args=args, metrics=metrics)
+        if not saved:
+            logger.warning(
+                f"Checkpoint save at step {step} was skipped by orbax "
+                "(duplicate or backward step)."
+            )
+            return None
+        return str(self._ckpt_root / str(step))
+
+    def _extract_metric(self, val_metrics: Mapping[str, Any]) -> float | None:
+        if self._cfg.metric_key not in val_metrics:
+            return None
+        try:
+            v = float(val_metrics[self._cfg.metric_key])
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(v):
+            return None
+        return v
+
+    def _is_better(self, value: float) -> bool:
+        current = self.best_metric
+        if current is None:
+            return True
+        return (
+            value > current if self._cfg.higher_is_better else value < current
+        )
+
+    def _upload(self, ckpt_path: str, step: int, *, aliases: list[str]) -> None:
+        if not hasattr(logger, "artifact"):
+            return
+        try:
+            logger.artifact(
+                {
+                    "path": ckpt_path,
+                    "name": self._artifact_name,
+                    "type": self._cfg.artifact_type,
+                    "aliases": aliases,
+                },
+                step=step,
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to upload checkpoint to W&B at step {step}: {exc}"
+            )

--- a/src/flowgym/make.py
+++ b/src/flowgym/make.py
@@ -1,4 +1,4 @@
-"""Module for compiling, saving, and loading flow field estimators."""
+"""Module for compiling, saving, and loading flow field estimator models."""
 
 from __future__ import annotations
 
@@ -22,7 +22,9 @@ from flax.core import FrozenDict, freeze
 from goggles import get_logger
 from goggles.history.types import History
 
-# Estimators
+# Models
+from flowgym._synthpix_compat import install_restore_state_shim
+from flowgym.checkpoint_source import resolve_checkpoint_source
 from flowgym.common.base import Estimator
 from flowgym.common.base.trainable_state import (
     EstimatorTrainableState,
@@ -38,6 +40,11 @@ from flowgym.types import (
 from flowgym.utils import DEBUG, MissingDependency
 
 logger = get_logger(__name__)
+
+# Patch synthpix's restore_state once at import time: it substitutes a
+# NaN-shape ShapeDtypeStruct placeholder that orbax 0.11+ chokes on.
+# See ``flowgym._synthpix_compat`` for the full rationale.
+install_restore_state_shim()
 
 
 def make_manager(ckpt_dir: Path, keep: int = 3) -> ocp.CheckpointManager:
@@ -60,10 +67,7 @@ def make_manager(ckpt_dir: Path, keep: int = 3) -> ocp.CheckpointManager:
 
 @overload
 def compile_model(
-    model: Estimator,
-    estimates: None,
-    jit: bool = True,
-    history_size: int = 1,
+    model: Estimator, estimates: None, jit: bool = True, history_size: int = 1
 ) -> tuple[
     None,
     CompiledComputeEstimateFn,
@@ -94,7 +98,7 @@ def compile_model(
     """Compile the model for JAX.
 
     Args:
-        model: The flow field model instance.
+        model: The flow field estimator model.
         estimates: Example estimates for shape inference.
         jit: Whether to use JIT compilation.
         history_size: The size of the history for the model.
@@ -135,6 +139,56 @@ def compile_model(
     return create_state_fn, compute_estimate_fn
 
 
+def build_save_args(
+    state: NNEstimatorTrainableState,
+    step: int,
+    model: Estimator | None = None,
+    sampler: Any | None = None,
+) -> ocp.args.Composite:
+    """Build the Composite save args for one checkpoint step.
+
+    Bundles the trainable state, the optimizer config (if recoverable
+    from the model), and any sampler-side checkpoint args into a single
+    Composite so orbax saves the trainer state atomically.
+
+    Args:
+        state: Trainable state to serialize.
+        step: Training step (also recorded inside the state payload).
+        model: Estimator instance, used to extract the optimizer config
+            via ``model.optimizer_config`` / ``model.opt_config`` if
+            present.
+        sampler: Synthpix sampler whose grain state should be
+            checkpointed alongside the model. Pass ``None`` to skip.
+
+    Returns:
+        A Composite ready to hand to ``CheckpointManager.save(args=...)``.
+    """
+    item = {
+        "step": step,
+        "params": state.params,
+        "opt_state": state.opt_state,
+        "extras": state.extras,
+    }
+    save_args: dict[str, ocp.args.CheckpointArgs] = {
+        "state": ocp.args.StandardSave(item)  # pyright: ignore[reportCallIssue]
+    }
+    if model is not None:
+        opt_cfg = getattr(
+            model, "optimizer_config", getattr(model, "opt_config", None)
+        )
+        if opt_cfg is not None:
+            save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # pyright: ignore[reportCallIssue]
+    if sampler is not None:
+        try:
+            sampler_args = synthpix.checkpoint_args(sampler)
+            save_args.update(
+                sampler_args.items()  # pyright: ignore[reportAttributeAccessIssue]
+            )
+        except Exception as e:
+            logger.warning(f"Failed to prepare sampler checkpoint args: {e}")
+    return ocp.args.Composite(**save_args)
+
+
 def save_model(
     state: NNEstimatorTrainableState,
     out_dir: str | Path,
@@ -144,9 +198,12 @@ def save_model(
     sampler: Any | None = None,
     keep: int = 3,
 ) -> str:
-    """Save a training checkpoint using Orbax.
+    """Save a single checkpoint via a short-lived ``CheckpointManager``.
 
-    Checkpoint saved to out_dir/checkpoints/<model_name>/<step>.
+    Intended for one-off saves outside the training loop (CLI tooling,
+    tests). Inside a training loop, prefer ``flowgym.checkpointing.
+    Checkpointer`` — it keeps a single long-lived manager across saves,
+    which is ~200ms/save cheaper and unlocks orbax's async pipeline.
 
     Args:
         state: The trainable state to save (PyTree).
@@ -167,7 +224,6 @@ def save_model(
     out_dir = Path(out_dir)
     out_dir = out_dir.resolve()
 
-    # Decide on a step number
     if step is None:
         if hasattr(state, "step"):
             step = int(state.step)
@@ -175,50 +231,15 @@ def save_model(
             raise ValueError("step not provided and state has no 'step' attr")
     step = int(step)
 
-    # Nesting: out_dir/checkpoints/<model_name>/<step>
     parts = [out_dir, "checkpoints"]
     if model_name is not None:
         parts.append(model_name)
-
     ckpt_root = Path(*parts)
     ckpt_root.mkdir(parents=True, exist_ok=True)
 
-    # We use the 'ocp.args' API
-    item = {
-        "step": step,
-        "params": state.params,
-        "opt_state": state.opt_state,
-        "extras": state.extras,
-    }
-
-    # Define the save arguments
-    save_args: dict[str, ocp.args.CheckpointArgs] = {
-        "state": ocp.args.StandardSave(item)  # pyright: ignore[reportCallIssue]
-    }
-
-    # Extract and save optimizer config separately (as it contains strings)
-    if model is not None:
-        opt_cfg = getattr(
-            model,
-            "optimizer_config",
-            getattr(model, "opt_config", None),
-        )
-        if opt_cfg is not None:
-            save_args["opt_config"] = ocp.args.JsonSave(opt_cfg)  # pyright: ignore[reportCallIssue]
-
-    if sampler is not None:
-        try:
-            sampler_args = synthpix.checkpoint_args(sampler)
-            # Flatten Composite args to root level for atomic saving
-            # of (state, sampler, grain) side-by-side.
-            save_args.update(
-                sampler_args.items()  # pyright: ignore[reportAttributeAccessIssue]
-            )
-        except Exception as e:
-            logger.warning(f"Failed to prepare sampler checkpoint args: {e}")
-
+    args = build_save_args(state, step, model=model, sampler=sampler)
     with make_manager(ckpt_root, keep=keep) as mngr:
-        mngr.save(step=step, args=ocp.args.Composite(**save_args))
+        mngr.save(step=step, args=args)
         mngr.wait_until_finished()
 
     return str(ckpt_root / str(step))
@@ -387,7 +408,7 @@ def load_model(
 
 @overload
 def make_estimator(
-    estimator_config: dict,
+    model_config: dict,
     image_shape: tuple,
     estimate_shape: tuple,
     load_from: str | None = None,
@@ -402,7 +423,7 @@ def make_estimator(
 
 @overload
 def make_estimator(
-    estimator_config: dict,
+    model_config: dict,
     image_shape: tuple,
     estimate_shape: None,
     load_from: str | None = None,
@@ -417,7 +438,7 @@ def make_estimator(
 
 @overload
 def make_estimator(
-    estimator_config: dict,
+    model_config: dict,
     image_shape: tuple | None = None,
     estimate_shape: tuple | None = None,
     load_from: str | None = None,
@@ -431,7 +452,7 @@ def make_estimator(
 
 
 def make_estimator(
-    estimator_config: dict,
+    model_config: dict,
     image_shape: tuple | None = None,
     estimate_shape: tuple | None = None,
     load_from: str | None = None,
@@ -446,43 +467,42 @@ def make_estimator(
 
     If load_from is not provided, a new trainable state is created.
 
-    estimator_config keys:
+    model_config keys:
     - estimator: Name of the estimator.
-    - estimate_type: Type of the estimator ("flow" or "density").
+    - estimator_type: Type of the estimator ("flow" or "density").
     - config: Configuration dictionary for the estimator.
 
     Args:
-        estimator_config: Configuration dictionary for the estimator.
+        model_config: Configuration dictionary for the estimator.
         image_shape: Shape of the input images (B, H, W).
         estimate_shape: Shape of the estimate. Defaults to (B, H, W, 2).
-        load_from: Path to load the trained estimator state.
+        load_from: Path to load the trained model state. May also be a
+            ``wandb://[entity/]project/name[:alias][/subpath]`` URI;
+            the artifact is downloaded and the resolved local path is
+            used. See :mod:`flowgym.checkpoint_source` for the grammar.
         rng: Random number generator key or seed.
 
     Returns:
-        EstimatorTrainableState: The trainable state of the estimator.
-        callable: Function to create the estimator state.
-        callable: Function to compute the estimator estimate.
-        Estimator: The estimator instance.
+        EstimatorTrainableState: The trainable state of the model.
+        callable: Function to create the model state.
+        callable: Function to compute the model estimate.
+        Estimator: The model instance.
 
     Raises:
-        ValueError: If estimator not found or estimator loading fails.
+        ValueError: If estimator not found or model loading fails.
     """
     # Import here to avoid circular dependency
     from flowgym import ALL_ESTIMATORS as ESTIMATORS  # noqa: PLC0415
 
     # Extract the estimator class from the config
-    if estimator_config["estimator"] not in ESTIMATORS:
-        raise ValueError(
-            f"Estimator {estimator_config['estimator']} not found."
-        )
-    estimator_class = ESTIMATORS.get(estimator_config["estimator"])
-    if estimator_class is None:
-        raise ValueError(
-            f"Estimator {estimator_config['estimator']} not found."
-        )
-    elif isinstance(estimator_class, MissingDependency):
-        estimator_class()  # Raises MissingDependency error
-        # Type narrowing: estimator_class is not MissingDependency here
+    if model_config["estimator"] not in ESTIMATORS:
+        raise ValueError(f"Estimator {model_config['estimator']} not found.")
+    model_class = ESTIMATORS.get(model_config["estimator"])
+    if model_class is None:
+        raise ValueError(f"Estimator {model_config['estimator']} not found.")
+    elif isinstance(model_class, MissingDependency):
+        model_class()  # Raises MissingDependency error
+        # Type narrowing: model_class is not MissingDependency here
         raise ValueError("Unreachable")  # pragma: no cover
 
     if rng is None:
@@ -490,39 +510,44 @@ def make_estimator(
     elif isinstance(rng, int):
         rng = jax.random.PRNGKey(rng)
 
-    # Create the estimator instance
-    estimator = cast(type[Estimator], estimator_class).from_config(
-        estimator_config["config"]
+    # Create the model instance
+    model = cast(type[Estimator], model_class).from_config(
+        model_config["config"]
         | {
             "estimate_shape": estimate_shape,
             "image_shape": image_shape,
             "rng": rng,
         }
     )
-    logger.info("Estimator created successfully.")
+    logger.info("Model created successfully.")
 
     # Load or create the trainable state
     if load_from:
-        if estimator_config["estimator"] == "raft_torch":
+        # ``load_from`` may be a plain path or a ``wandb://`` URI; the
+        # resolver downloads the artifact (when applicable) and hands
+        # back a local filesystem path the downstream loaders consume
+        # unchanged.
+        resolved_load_from = resolve_checkpoint_source(load_from)
+        if model_config["estimator"] == "raft_torch":
             if torch is None:
-                raise ValueError("torch required for raft_torch estimator")
-            checkpoint = torch.load(load_from, map_location="cuda")
-            estimator_any = estimator  # type: Any
-            estimator_any.raft.load_state_dict(
+                raise ValueError("torch required for raft_torch model")
+            checkpoint = torch.load(resolved_load_from, map_location="cuda")
+            model_any = model  # type: Any
+            model_any.raft.load_state_dict(
                 checkpoint["model_state_dict"], strict=False
             )
             trained_state = None
         else:
-            mode = estimator_config.get("load_mode", "params_only")
-            template_state = estimator.create_trainable_state(
+            mode = model_config.get("load_mode", "params_only")
+            template_state = model.create_trainable_state(
                 jnp.zeros(image_shape, dtype=jnp.float32), key=rng
             )
             if isinstance(template_state, NNEstimatorTrainableState):
                 trained_state = load_model(
-                    load_from, template_state, mode=mode
+                    resolved_load_from, template_state, mode=mode
                 )
             else:
-                raise ValueError("Estimator is not a neural network estimator.")
+                raise ValueError("Model is not a neural network estimator.")
         logger.info("Trainable state loaded successfully.")
     # Create a dummy input to initialize the trainable state
     elif image_shape is None:
@@ -532,7 +557,7 @@ def make_estimator(
         trained_state = None
     else:
         sample_images = jnp.zeros(image_shape, dtype=jnp.float32)
-        trained_state = estimator.create_trainable_state(sample_images, key=rng)
+        trained_state = model.create_trainable_state(sample_images, key=rng)
         logger.info("Trainable state created successfully.")
 
     if estimate_shape is None:
@@ -550,14 +575,14 @@ def make_estimator(
     else:
         dummy_estimates = jnp.zeros(estimate_shape, dtype=jnp.float32)
     create_state_fn, compute_estimate_fn = compile_model(
-        estimator,
+        model,
         dummy_estimates,
-        estimator_config["config"].get("jit", False) and not DEBUG,
-        history_size=estimator_config["config"].get("history_size", 1),
+        model_config["config"].get("jit", False) and not DEBUG,
+        history_size=model_config["config"].get("history_size", 1),
     )
-    logger.info("Estimator compiled successfully.")
+    logger.info("Model compiled successfully.")
 
-    return trained_state, create_state_fn, compute_estimate_fn, estimator
+    return trained_state, create_state_fn, compute_estimate_fn, model
 
 
 def select_gt(estimate_type: str, batch: SynthpixBatch) -> jnp.ndarray:

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from synthpix.sampler import (
 
 from compare import comparison
 from eval import eval, eval_full_dataset
+from flowgym.checkpointing import CheckpointConfig
 from flowgym.common.base import NNEstimatorTrainableState
 
 # Training environment
@@ -255,12 +256,16 @@ if __name__ == "__main__":
                 "NNEstimatorTrainableState."
             )
 
+        ckpt_cfg = CheckpointConfig.from_configs(
+            estimator_config, dataset_config
+        )
         try:
             train(
                 estimator=estimator,
                 estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
+                checkpoint_config=ckpt_cfg,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
                 env=env,
@@ -333,12 +338,16 @@ if __name__ == "__main__":
                     )
             cache_manager = CacheManager(**caching_config)
 
+        ckpt_cfg = CheckpointConfig.from_configs(
+            estimator_config, dataset_config
+        )
         try:
             train_supervised(
                 estimator=estimator,
                 estimator_config=estimator_config,
                 trainable_state=trainable_state,
                 out_dir=out_dir,
+                checkpoint_config=ckpt_cfg,
                 create_state_fn=create_state_fn,
                 compute_estimate_fn=compute_estimate_fn,
                 sampler=sampler,

--- a/src/train.py
+++ b/src/train.py
@@ -1,5 +1,6 @@
 """Train flow estimators with synthetic data using reinforcement learning."""
 
+import contextlib
 import time
 
 import goggles as gg
@@ -8,9 +9,9 @@ import jax.numpy as jnp
 import numpy as np
 from goggles import Metrics
 
+from flowgym.checkpointing import CheckpointConfig, Checkpointer
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
 from flowgym.environment.fluid_env import EnvState, FluidEnv, Observation
-from flowgym.make import save_model
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
     CompiledComputeEstimateFn,
@@ -42,6 +43,7 @@ def train(
     replay_buffer_capacity: int = 10000,
     replay_ratio: float = 0.0,
     prefetch_replay_size: int = 0,
+    checkpoint_config: CheckpointConfig | None = None,
 ) -> None:
     """Train the flow estimator.
 
@@ -63,6 +65,11 @@ def train(
         replay_ratio: Ratio of replay samples to collected samples.
         prefetch_replay_size: Prefetch buffer size for replay. If > 0,
             enables GPU prefetch.
+        checkpoint_config: Checkpointer policy. RL training has no
+            validation loop, so only ``save_periodic`` fires here and
+            ``save_only_best`` / ``wandb_upload="best"`` modes are
+            effectively no-ops; ``wandb_upload="every"`` still uploads
+            each periodic save (alias ``latest``).
     """
     # Create the training step function
     train_step_fn = estimator.create_train_step()
@@ -96,7 +103,18 @@ def train(
             f"Replay buffer initialized with capacity {replay_buffer_capacity}."
         )
 
-    with GracefulShutdown("Stop detected, finishing epoch...") as g:
+    with contextlib.ExitStack() as stack:
+        checkpointer = stack.enter_context(
+            Checkpointer(
+                out_dir=out_dir,
+                model=estimator,
+                sampler=env_state[0],
+                config=checkpoint_config or CheckpointConfig(),
+            )
+        )
+        g = stack.enter_context(
+            GracefulShutdown("Stop detected, finishing epoch...")
+        )
         episode_idx = 0
         done = jnp.array([False] * obs[0].shape[0], dtype=jnp.bool_)
         t_total = time.time()
@@ -255,13 +273,14 @@ def train(
                 logger.info(f"Episode {episode_idx} - {k}: {avg_value}")
 
             if episode_idx % save_every == 0:
-                save_model(
-                    state=trainable_state,
-                    out_dir=out_dir,
-                    model=estimator,
-                    model_name=f"{estimator.__class__.__name__}-{episode_idx}",
-                    sampler=env_state[0],
+                saved_path = checkpointer.save_periodic(
+                    trainable_state, episode_idx
                 )
+                if saved_path is not None:
+                    logger.info(
+                        f"Checkpoint saved at episode {episode_idx} -> "
+                        f"{saved_path}"
+                    )
 
     t_total = time.time() - t_total
     logger.info(f"Training took {t_total} seconds.")

--- a/src/train_supervised.py
+++ b/src/train_supervised.py
@@ -11,8 +11,8 @@ import numpy as np
 from synthpix.sampler import Sampler
 
 from eval import evaluate_batches
+from flowgym.checkpointing import CheckpointConfig, Checkpointer
 from flowgym.common.base import Estimator, NNEstimatorTrainableState
-from flowgym.make import save_model
 from flowgym.training.caching import CacheManager, enrich_batch
 from flowgym.training.replay import ReplayBuffer
 from flowgym.types import (
@@ -49,6 +49,7 @@ def train_supervised(
     replay_ratio: float = 0.0,
     prefetch_replay_size: int = 0,
     cache_manager: CacheManager | None = None,
+    checkpoint_config: CheckpointConfig | None = None,
 ) -> None:
     """Train the flow estimator.
 
@@ -75,6 +76,10 @@ def train_supervised(
         prefetch_replay_size: Prefetch buffer size for replay. If > 0,
             enables GPU prefetch.
         cache_manager: Optional CacheManager for read-through caching.
+        checkpoint_config: Checkpointer policy (W&B upload mode, best-
+            tracking, save cadence). When omitted, a default is built
+            from ``save_only_best`` and the trainer routes all saves
+            through ``Checkpointer``.
 
     Raises:
         ValueError: If estimate_type is not "flow" or "density", or if
@@ -95,8 +100,7 @@ def train_supervised(
 
     logger.info("Training step function compiled successfully.")
 
-    best_mean_error = float("inf")
-    last_val_metrics: dict | None = None
+    cfg = checkpoint_config or CheckpointConfig(save_only_best=save_only_best)
 
     # Initialize the replay buffer
     replay_buffer = None
@@ -111,6 +115,14 @@ def train_supervised(
         )
 
     with contextlib.ExitStack() as stack:
+        checkpointer = stack.enter_context(
+            Checkpointer(
+                out_dir=out_dir,
+                model=estimator,
+                sampler=sampler,
+                config=cfg,
+            )
+        )
         g = stack.enter_context(
             GracefulShutdown("Stop detected, finishing epoch...")
         )
@@ -171,8 +183,10 @@ def train_supervised(
                     elif isinstance(v, np.ndarray) and v.ndim == 0:
                         init_val_msg += f", {k}={float(v):.5f}"
                 logger.info(init_val_msg)
-                last_val_metrics = dict(val_metrics)
-                best_mean_error = mean_error
+                # Route the baseline through on_validation so it
+                # establishes the best-metric reference (and uploads
+                # when wandb_upload is enabled).
+                checkpointer.on_validation(trainable_state, 0, val_metrics)
             except Exception as e:
                 logger.error(f"Initial validation failed: {e}")
 
@@ -373,7 +387,15 @@ def train_supervised(
                         elif isinstance(v, np.ndarray) and v.ndim == 0:
                             val_msg += f", {k}={float(v):.5f}"
                     logger.info(val_msg)
-                    last_val_metrics = dict(val_metrics)
+                    saved_path = checkpointer.on_validation(
+                        trainable_state, batch_idx, val_metrics
+                    )
+                    if saved_path is not None:
+                        logger.info(
+                            f"Checkpoint saved at batch {batch_idx} -> "
+                            f"{saved_path} (best_metric="
+                            f"{checkpointer.best_metric})"
+                        )
 
                 if batch_idx % log_every == 0:
                     logger.scalar("loss", float(loss), step=batch_idx)
@@ -390,43 +412,14 @@ def train_supervised(
                 if batch_idx > 0 and (
                     batch_idx % save_every == 0 or batch_idx == num_batches - 1
                 ):
-                    if not save_only_best:
-                        save_model(
-                            state=trainable_state,
-                            out_dir=out_dir,
-                            step=batch_idx,
-                            model=estimator,
-                            model_name=estimator.__class__.__name__,
-                            sampler=sampler,
-                        )
-
-                    elif last_val_metrics is None:
+                    saved_path = checkpointer.save_periodic(
+                        trainable_state, batch_idx
+                    )
+                    if saved_path is not None:
                         logger.info(
-                            f"Skipping best-estimator save at batch "
-                            f"{batch_idx}: no validation computed yet."
+                            f"Periodic checkpoint saved at batch "
+                            f"{batch_idx} -> {saved_path}"
                         )
-                    else:
-                        # Only save if validation was actually computed
-                        current_mean_error = float(
-                            last_val_metrics["mean_error"]
-                        )
-
-                        if current_mean_error < best_mean_error:
-                            best_mean_error = current_mean_error
-
-                            save_model(
-                                state=trainable_state,
-                                out_dir=out_dir,
-                                step=batch_idx,
-                                model=estimator,
-                                model_name=estimator.__class__.__name__,
-                                sampler=sampler,
-                            )
-
-                            logger.info(
-                                f"New best estimator saved at batch {batch_idx}"
-                                f" (mean_error={current_mean_error:.6f})"
-                            )
 
                 # Reset sampler timer for next batch
                 t_sample_start = time.time()
@@ -495,6 +488,19 @@ def train_supervised(
                     elif isinstance(v, np.ndarray) and v.ndim == 0:
                         final_val_msg += f", {k}={float(v):.5f}"
                 logger.info(final_val_msg)
+                final_path = checkpointer.save_final(
+                    trainable_state,
+                    final_step,
+                    val_metrics=final_val_metrics,
+                )
+                if final_path is None:
+                    logger.info(
+                        f"Final checkpoint at step {final_step} skipped "
+                        "(orbax rejected the save — likely a duplicate of "
+                        "the last periodic checkpoint)."
+                    )
+                else:
+                    logger.info(f"Final checkpoint saved -> {final_path}")
             except Exception as e:
                 logger.error(f"Final validation failed: {e}")
 

--- a/tests/integration/training/test_full_integration.py
+++ b/tests/integration/training/test_full_integration.py
@@ -1,8 +1,11 @@
-"""Integration tests for the train and train_supervised end-to-end loops.
+"""Comprehensive integration tests for train and train_supervised loops.
 
-Exercises replay buffer, enrichment, checkpointing, validation, and
-metrics processing across train.py and train_supervised.py using
-DummyEstimator.
+These tests exercise all training features using DummyEstimator:
+- Replay buffer (initialization, push, sample)
+- Replay buffer enrichment via prepare_experience_for_replay
+- Checkpointing (save_model / load_model)
+- Validation (for train_supervised)
+- Metrics processing
 """
 
 from pathlib import Path
@@ -24,22 +27,56 @@ from train_supervised import train_supervised
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _mock_save_model(
-    state, out_dir, step=None, model=None, model_name=None, **kwargs
-):
-    """Mock save_model: make checkpoint dirs without writing."""
-    out_dir = Path(out_dir)
-    if model_name:
-        ckpt_dir = out_dir / "checkpoints" / model_name
-    else:
-        ckpt_dir = out_dir / "checkpoints"
-    ckpt_dir.mkdir(parents=True, exist_ok=True)
+class _FakeCheckpointer:
+    """In-process stand-in for ``Checkpointer`` used by integration tests.
 
-    if step is None and hasattr(state, "step"):
-        step = int(state.step)
-    step_dir = ckpt_dir / str(step)
-    step_dir.mkdir(exist_ok=True)
-    return str(step_dir)
+    Mirrors the public methods (``save_periodic``, ``save_final``,
+    ``on_validation``, ``close``, context manager protocol) and creates
+    one empty directory per save so the existing
+    ``out_dir/checkpoints/<step>`` glob-based assertions keep working
+    without touching real orbax I/O.
+    """
+
+    def __init__(self, out_dir, model=None, sampler=None, config=None):
+        self.out_dir = Path(out_dir)
+        self.save_calls: list[tuple[str, int]] = []
+
+    def _record_save(self, kind: str, step: int) -> str:
+        ckpt_dir = self.out_dir / "checkpoints"
+        ckpt_dir.mkdir(parents=True, exist_ok=True)
+        step_dir = ckpt_dir / str(step)
+        step_dir.mkdir(exist_ok=True)
+        self.save_calls.append((kind, step))
+        return str(step_dir)
+
+    def save_periodic(self, state, step):
+        return self._record_save("periodic", step)
+
+    def save_final(self, state, step):
+        return self._record_save("final", step)
+
+    def on_validation(self, state, step, val_metrics):
+        # Integration tests don't assert per-mode upload behavior, so a
+        # noop here is fine; train_supervised's other logging branches
+        # exercise the validation path.
+        return None
+
+    @property
+    def best_step(self):
+        return self.save_calls[-1][1] if self.save_calls else None
+
+    @property
+    def best_metric(self):
+        return None
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -50,8 +87,8 @@ def _mock_save_model(
 def test_train_supervised_full_integration(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """train_supervised runs validation and saves checkpoints end-to-end."""
-    estimator = DummyEstimator(train_type="supervised", enrichment_marker=True)
+    """Test train_supervised with replay buffer, validation, checkpointing."""
+    model = DummyEstimator(train_type="supervised", enrichment_marker=True)
 
     # Create a separate mock for validation sampler
     val_sampler = MagicMock()
@@ -75,10 +112,7 @@ def test_train_supervised_full_integration(
     # Mock both evaluate_batches and save_model
     with (
         patch("train_supervised.evaluate_batches") as mock_eval,
-        patch(
-            "train_supervised.save_model",
-            side_effect=_mock_save_model,
-        ),
+        patch("train_supervised.Checkpointer", side_effect=_FakeCheckpointer),
     ):
         mock_eval.return_value = {
             "mean_error": 0.1,
@@ -88,7 +122,7 @@ def test_train_supervised_full_integration(
         }
 
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -112,8 +146,13 @@ def test_train_supervised_full_integration(
             f"Expected at least 2 validation calls, got {mock_eval.call_count}"
         )
 
-    # Verify checkpoints were created
-    checkpoint_dirs = list(out_dir.glob("**/DummyEstimator/*"))
+    # Verify checkpoints were created — Checkpointer uses the flat
+    # ``out_dir/checkpoints/<step>/`` layout.
+    checkpoint_dirs = [
+        p
+        for p in out_dir.glob("**/checkpoints/*")
+        if p.is_dir() and p.name.isdigit()
+    ]
     assert len(checkpoint_dirs) >= 1, (
         "Expected at least one checkpoint to be saved"
     )
@@ -122,8 +161,8 @@ def test_train_supervised_full_integration(
 def test_train_supervised_replay_enrichment(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """prepare_experience_for_replay enriches experiences before buffer push."""
-    estimator = DummyEstimator(train_type="supervised", enrichment_marker=True)
+    """Test that replay preparation enriches stored experiences."""
+    model = DummyEstimator(train_type="supervised", enrichment_marker=True)
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -148,7 +187,7 @@ def test_train_supervised_replay_enrichment(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -161,7 +200,7 @@ def test_train_supervised_replay_enrichment(
             key=jax.random.PRNGKey(42),
         )
 
-    # Verify experiences were enriched with marker
+    # Verify experiences were enriched during replay preparation.
     assert len(pushed_experiences) > 0, (
         "Expected experiences to be pushed to buffer"
     )
@@ -175,8 +214,8 @@ def test_train_supervised_replay_enrichment(
 def test_train_supervised_checkpointing_roundtrip(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """save_model is called at the configured save_every interval."""
-    estimator = DummyEstimator(train_type="supervised")
+    """Test that checkpoints are saved at the expected intervals."""
+    model = DummyEstimator(train_type="supervised")
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -191,16 +230,17 @@ def test_train_supervised_checkpointing_roundtrip(
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    save_calls = []
+    instances: list[_FakeCheckpointer] = []
 
-    def tracking_save(*args, **kwargs):
-        save_calls.append((args, kwargs))
-        return _mock_save_model(*args, **kwargs)
+    def factory(*args, **kwargs):
+        inst = _FakeCheckpointer(*args, **kwargs)
+        instances.append(inst)
+        return inst
 
     # Run training to create a checkpoint
-    with patch("train_supervised.save_model", side_effect=tracking_save):
+    with patch("train_supervised.Checkpointer", side_effect=factory):
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -212,15 +252,18 @@ def test_train_supervised_checkpointing_roundtrip(
             key=jax.random.PRNGKey(42),
         )
 
-    # Verify save_model was called at expected intervals (batch 3)
-    assert len(save_calls) >= 1, "Expected at least one save_model call"
+    # Verify save_periodic / save_final fired at least once.
+    assert instances, "Expected a Checkpointer to be constructed"
+    assert len(instances[0].save_calls) >= 1, (
+        "Expected at least one checkpoint save"
+    )
 
 
-def test_train_supervised_no_enrichment_without_flag(
+def test_train_supervised_no_replay_enrichment_when_disabled(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """Replay experiences carry no enrichment marker when the flag is off."""
-    estimator = DummyEstimator(train_type="supervised", enrichment_marker=False)
+    """Test that replay enrichment is skipped when disabled."""
+    model = DummyEstimator(train_type="supervised", enrichment_marker=False)
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -245,7 +288,7 @@ def test_train_supervised_no_enrichment_without_flag(
 
     with patch.object(ReplayBuffer, "push", tracking_push):
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -258,7 +301,7 @@ def test_train_supervised_no_enrichment_without_flag(
             key=jax.random.PRNGKey(42),
         )
 
-    # Verify experiences were NOT enriched (no marker)
+    # Verify experiences were not enriched.
     assert len(pushed_experiences) > 0, "Expected experiences to be pushed"
     for exp in pushed_experiences:
         assert "_enriched" not in exp.state, (
@@ -272,8 +315,8 @@ def test_train_supervised_no_enrichment_without_flag(
 
 
 def test_train_rl_full_integration(tmp_path, mock_env):
-    """RL train loop completes episodes and writes checkpoint directories."""
-    estimator = DummyEstimator(train_type="rl")
+    """Test train (RL) loop with replay buffer and checkpointing."""
+    model = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -298,13 +341,11 @@ def test_train_rl_full_integration(tmp_path, mock_env):
     out_dir = tmp_path / "checkpoints"
     out_dir.mkdir()
 
-    # Run training with mocked save_model
-    with (
-        patch("train.save_model", side_effect=_mock_save_model),
-        patch("train.log_flow_estimate"),
-    ):
+    # Run training with mocked Checkpointer (train.py imports it
+    # under its own namespace).
+    with patch("train.Checkpointer", side_effect=_FakeCheckpointer):
         train(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(out_dir),
@@ -321,16 +362,21 @@ def test_train_rl_full_integration(tmp_path, mock_env):
             replay_ratio=1.0,
         )
 
-    # Verify checkpoints were created
-    checkpoint_dirs = list(out_dir.glob("**/DummyEstimator-*"))
+    # Verify checkpoints were created — Checkpointer uses the flat
+    # ``out_dir/checkpoints/<episode>/`` layout.
+    checkpoint_dirs = [
+        p
+        for p in out_dir.glob("**/checkpoints/*")
+        if p.is_dir() and p.name.isdigit()
+    ]
     assert len(checkpoint_dirs) >= 1, (
         "Expected at least one checkpoint to be saved"
     )
 
 
 def test_train_rl_replay_buffer_used(tmp_path, mock_env):
-    """ReplayBuffer is constructed exactly once when RL training starts."""
-    estimator = DummyEstimator(train_type="rl")
+    """Test that replay buffer is initialized and used in RL training."""
+    model = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -353,12 +399,9 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
         return state, {"dummy": jnp.array(0.0)}
 
     # Track ReplayBuffer initialization
-    with (
-        patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer,
-        patch("train.log_flow_estimate"),
-    ):
+    with patch("train.ReplayBuffer", wraps=ReplayBuffer) as mock_buffer:
         train(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
@@ -379,8 +422,8 @@ def test_train_rl_replay_buffer_used(tmp_path, mock_env):
 
 
 def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
-    """A positive replay_ratio causes extra train-step calls from replay."""
-    estimator = DummyEstimator(train_type="rl")
+    """Test that replay buffer sampling is called when replay_ratio > 0."""
+    model = DummyEstimator(train_type="rl")
     env, obs, env_state = mock_env
 
     def apply_fn(params, x):
@@ -404,20 +447,17 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
 
     # Track train_step_fn calls
     train_step_calls = []
-    original_train_step = estimator.create_train_step()
+    original_train_step = model.create_train_step()
 
     def tracking_train_step(*args, **kwargs):
         train_step_calls.append((args, kwargs))
         return original_train_step(*args, **kwargs)
 
-    with (
-        patch.object(
-            estimator, "create_train_step", return_value=tracking_train_step
-        ),
-        patch("train.log_flow_estimate"),
+    with patch.object(
+        model, "create_train_step", return_value=tracking_train_step
     ):
         train(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=trainable_state,
             out_dir=str(tmp_path),
@@ -448,8 +488,8 @@ def test_train_rl_replay_buffer_samples(tmp_path, mock_env):
 def test_train_supervised_validation_runs(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """evaluate_batches is invoked at each val_interval during training."""
-    estimator = DummyEstimator(train_type="supervised")
+    """Test that validation is executed at specified intervals."""
+    model = DummyEstimator(train_type="supervised")
 
     val_sampler = MagicMock()
     val_sampler.shutdown = MagicMock()
@@ -479,7 +519,7 @@ def test_train_supervised_validation_runs(
         }
 
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -502,8 +542,8 @@ def test_train_supervised_validation_runs(
 def test_train_supervised_save_only_best(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """save_only_best triggers a checkpoint whenever validation error drops."""
-    estimator = DummyEstimator(train_type="supervised")
+    """Test save_only_best mode saves only when validation improves."""
+    model = DummyEstimator(train_type="supervised")
 
     val_sampler = MagicMock()
     val_sampler.shutdown = MagicMock()
@@ -535,18 +575,19 @@ def test_train_supervised_save_only_best(
             "errors": jnp.array([err]),
         }
 
-    save_calls = []
+    instances: list[_FakeCheckpointer] = []
 
-    def tracking_save(*args, **kwargs):
-        save_calls.append((args, kwargs))
-        return _mock_save_model(*args, **kwargs)
+    def factory(*args, **kwargs):
+        inst = _FakeCheckpointer(*args, **kwargs)
+        instances.append(inst)
+        return inst
 
     with (
         patch("train_supervised.evaluate_batches", side_effect=mock_evaluate),
-        patch("train_supervised.save_model", side_effect=tracking_save),
+        patch("train_supervised.Checkpointer", side_effect=factory),
     ):
         train_supervised(
-            estimator=estimator,
+            estimator=model,
             estimator_config={"config": {"jit": False}},
             trainable_state=dummy_trainable_state,
             out_dir=str(out_dir),
@@ -564,7 +605,7 @@ def test_train_supervised_save_only_best(
 
     # In save_only_best mode, we save when mean_error improves
     # With errors [0.5, 0.3, 0.2, 0.1], each is an improvement
-    assert len(save_calls) >= 1, (
+    assert instances and len(instances[0].save_calls) >= 1, (
         "Expected at least one save in save_only_best mode"
     )
 
@@ -572,8 +613,8 @@ def test_train_supervised_save_only_best(
 def test_train_supervised_metrics_logged(
     tmp_path, mock_sampler, dummy_trainable_state
 ):
-    """Metrics returned by the train step are processed without error."""
-    estimator = DummyEstimator(train_type="supervised")
+    """Test that metrics from train step are properly logged."""
+    model = DummyEstimator(train_type="supervised")
 
     def create_state_fn(img, key):
         B, H, W = img.shape
@@ -590,7 +631,7 @@ def test_train_supervised_metrics_logged(
 
     # Run training
     train_supervised(
-        estimator=estimator,
+        estimator=model,
         estimator_config={"config": {"jit": False}},
         trainable_state=dummy_trainable_state,
         out_dir=str(out_dir),

--- a/tests/unit/training/test_checkpoint_source.py
+++ b/tests/unit/training/test_checkpoint_source.py
@@ -1,0 +1,290 @@
+"""Tests for ``flowgym.checkpoint_source``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from flowgym.checkpoint_source import (
+    WANDB_URI_PREFIX,
+    is_wandb_uri,
+    parse_wandb_uri,
+    resolve_checkpoint_source,
+)
+
+# ──────────────────────────────────────────────────────────────────────────
+# Prefix detection
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("wandb://entity/project/name:alias", True),
+        ("wandb://name:alias", True),
+        ("wandb://", True),  # malformed but matches the prefix
+        ("/tmp/some/dir", False),
+        ("relative/path", False),
+        ("https://example.com/foo", False),
+        ("wandb-artifact://entity/project/name:alias", False),
+        ("", False),
+    ],
+)
+def test_is_wandb_uri(source: str, expected: bool) -> None:
+    """``is_wandb_uri`` accepts only ``wandb://`` prefixes."""
+    assert is_wandb_uri(source) is expected
+
+
+def test_wandb_uri_prefix_constant() -> None:
+    """The exported prefix constant is the canonical scheme string."""
+    assert WANDB_URI_PREFIX == "wandb://"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# URI parsing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_full_uri_with_entity_alias_subpath() -> None:
+    """Full URI with entity/project/name:alias/subpath is parsed cleanly."""
+    ref, subpath = parse_wandb_uri(
+        "wandb://artofpiv/RAFT32_finetuning/"
+        "raft32_piv_pretrained:pretrained/jax/checkpoints/0"
+    )
+    assert ref == "artofpiv/RAFT32_finetuning/raft32_piv_pretrained:pretrained"
+    assert subpath == "jax/checkpoints/0"
+
+
+def test_parse_uri_without_subpath_returns_empty_string() -> None:
+    """When no subpath is present after the alias, the subpath is ``''``."""
+    ref, subpath = parse_wandb_uri(
+        "wandb://artofpiv/RAFT32_finetuning/raft32_piv_pretrained:pretrained"
+    )
+    assert ref == "artofpiv/RAFT32_finetuning/raft32_piv_pretrained:pretrained"
+    assert subpath == ""
+
+
+def test_parse_uri_without_alias_keeps_default_latest() -> None:
+    """When no ``:alias`` is given the wandb reference is passed through.
+
+    The downstream wandb API defaults to the ``latest`` alias in that
+    case; the parser itself must not invent one.
+    """
+    ref, subpath = parse_wandb_uri(
+        "wandb://artofpiv/RAFT32_finetuning/raft32_piv_pretrained"
+    )
+    assert ref == "artofpiv/RAFT32_finetuning/raft32_piv_pretrained"
+    assert subpath == ""
+
+
+def test_parse_uri_with_subpath_but_no_alias() -> None:
+    """The subpath is everything after the last ``/`` of the artifact ref.
+
+    Without an alias the first slash in ``project/name`` is part of the
+    artifact reference, so we can only safely accept subpaths together
+    with an explicit alias to keep the boundary unambiguous.
+    """
+    with pytest.raises(ValueError):
+        parse_wandb_uri(
+            "wandb://artofpiv/RAFT32_finetuning/"
+            "raft32_piv_pretrained/jax/checkpoints/0"
+        )
+
+
+def test_parse_uri_rejects_non_wandb_scheme() -> None:
+    """The parser raises on non-``wandb://`` input."""
+    with pytest.raises(ValueError):
+        parse_wandb_uri("/tmp/some/dir")
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "wandb://",  # empty body
+        "wandb://:alias",  # empty artifact reference
+        "wandb://entity/project/name:",  # empty alias
+        "wandb://entity/project/name:/sub",  # empty alias + subpath
+        "wandb://:alias/sub",  # empty ref with subpath
+    ],
+)
+def test_parse_uri_rejects_empty_components(uri: str) -> None:
+    """Empty body, ref, or alias produce a clear ``ValueError``."""
+    with pytest.raises(ValueError):
+        parse_wandb_uri(uri)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# resolve_checkpoint_source
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_plain_path_passes_through(tmp_path: Path) -> None:
+    """Non-wandb sources are returned as absolute ``Path`` unchanged."""
+    target = tmp_path / "ckpt"
+    target.mkdir()
+    resolved = resolve_checkpoint_source(str(target))
+    assert resolved == target.resolve()
+
+
+def test_resolve_plain_path_accepts_path_object(tmp_path: Path) -> None:
+    """``Path`` inputs are returned resolved."""
+    target = tmp_path / "ckpt"
+    target.mkdir()
+    resolved = resolve_checkpoint_source(target)
+    assert resolved == target.resolve()
+
+
+def _install_fake_wandb(
+    monkeypatch: pytest.MonkeyPatch,
+    download_root: Path,
+    *,
+    active_run: bool,
+) -> dict[str, Any]:
+    """Install a stub ``wandb`` module on ``sys.modules``.
+
+    Records the artifact reference passed to ``use_artifact`` / ``Api``
+    and returns the captures dict so the caller can assert on it.
+
+    Args:
+        monkeypatch: The pytest monkeypatch fixture.
+        download_root: Path to return from ``Artifact.download``.
+        active_run: When True, ``wandb.run`` returns a run-like mock so
+            the resolver uses ``run.use_artifact`` (recording the load
+            as a run input). When False, ``wandb.run`` is ``None`` and
+            the resolver falls back to ``wandb.Api().artifact``.
+
+    Returns:
+        Dict with keys ``ref`` (the reference passed in) and ``route``
+        ("run" or "api") so the test can assert which path was taken.
+    """
+    captures: dict[str, Any] = {"ref": None, "route": None}
+
+    fake_artifact = MagicMock()
+    fake_artifact.download.return_value = str(download_root)
+
+    fake_run = MagicMock()
+
+    def _use_artifact(ref: str) -> Any:
+        captures["ref"] = ref
+        captures["route"] = "run"
+        return fake_artifact
+
+    fake_run.use_artifact.side_effect = _use_artifact
+
+    fake_api_instance = MagicMock()
+
+    def _api_artifact(ref: str) -> Any:
+        captures["ref"] = ref
+        captures["route"] = "api"
+        return fake_artifact
+
+    fake_api_instance.artifact.side_effect = _api_artifact
+
+    fake_wandb = MagicMock()
+    fake_wandb.run = fake_run if active_run else None
+    fake_wandb.Api.return_value = fake_api_instance
+
+    monkeypatch.setitem(__import__("sys").modules, "wandb", fake_wandb)
+    return captures
+
+
+def test_resolve_wandb_uri_uses_run_use_artifact_when_run_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An active wandb run routes the download through ``run.use_artifact``.
+
+    This is the preferred path because it records the artifact as a
+    run input so the wandb UI can trace data lineage.
+    """
+    captures = _install_fake_wandb(monkeypatch, tmp_path, active_run=True)
+
+    resolved = resolve_checkpoint_source("wandb://entity/project/name:alias")
+
+    assert captures["route"] == "run"
+    assert captures["ref"] == "entity/project/name:alias"
+    assert resolved == tmp_path.resolve()
+
+
+def test_resolve_wandb_uri_uses_api_when_no_active_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no wandb run is active, ``Api().artifact`` is used instead."""
+    captures = _install_fake_wandb(monkeypatch, tmp_path, active_run=False)
+
+    resolved = resolve_checkpoint_source("wandb://entity/project/name:alias")
+
+    assert captures["route"] == "api"
+    assert captures["ref"] == "entity/project/name:alias"
+    assert resolved == tmp_path.resolve()
+
+
+def test_resolve_wandb_uri_appends_subpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The in-artifact subpath is appended to the download root."""
+    inner = tmp_path / "jax" / "checkpoints" / "0"
+    inner.mkdir(parents=True)
+    _install_fake_wandb(monkeypatch, tmp_path, active_run=True)
+
+    resolved = resolve_checkpoint_source(
+        "wandb://entity/project/name:alias/jax/checkpoints/0"
+    )
+    assert resolved == inner.resolve()
+
+
+def test_resolve_wandb_uri_raises_when_subpath_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A subpath that does not exist in the downloaded tree fails loudly.
+
+    Silent fallback to the download root would mask user typos and
+    surface as a confusing "no checkpoints found" error from
+    ``load_model`` much further down the stack.
+    """
+    _install_fake_wandb(monkeypatch, tmp_path, active_run=True)
+
+    with pytest.raises(FileNotFoundError):
+        resolve_checkpoint_source("wandb://entity/project/name:alias/nope/here")
+
+
+def test_resolve_wandb_uri_rejects_subpath_escaping_download_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A subpath containing ``..`` that escapes the root is rejected.
+
+    Even if such a path happens to exist on disk, returning it would
+    let a wandb URI hand back an arbitrary filesystem location, which
+    the caller did not authorize.
+    """
+    download_root = tmp_path / "download"
+    download_root.mkdir()
+    # Create a sibling that the ``..`` traversal would otherwise reach.
+    (tmp_path / "outside").mkdir()
+
+    _install_fake_wandb(monkeypatch, download_root, active_run=True)
+
+    with pytest.raises(ValueError, match="escapes the artifact download root"):
+        resolve_checkpoint_source(
+            "wandb://entity/project/name:alias/../outside"
+        )
+
+
+def test_resolve_wandb_uri_rejects_absolute_subpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An absolute in-artifact subpath is rejected up front."""
+    _install_fake_wandb(monkeypatch, tmp_path, active_run=True)
+
+    # The parser keeps a leading ``/`` as part of the subpath, so feed
+    # one directly through ``resolve_checkpoint_source``'s plumbing by
+    # constructing a URI where the subpath starts with ``/``. Because
+    # ``parse_wandb_uri`` splits on the first ``/`` after the alias,
+    # the subpath portion that reaches the safety check is e.g.
+    # ``/etc/passwd``.
+    with pytest.raises(ValueError, match="absolute"):
+        resolve_checkpoint_source(
+            "wandb://entity/project/name:alias//etc/passwd"
+        )

--- a/tests/unit/training/test_checkpointer.py
+++ b/tests/unit/training/test_checkpointer.py
@@ -1,0 +1,595 @@
+"""Unit tests for ``flowgym.checkpointing.Checkpointer``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flowgym.checkpointing import CheckpointConfig, Checkpointer
+
+
+class _FakeManager:
+    """In-memory stand-in for ``ocp.CheckpointManager``.
+
+    Mirrors the slice of the API the Checkpointer actually exercises
+    (``save``, ``best_step``, ``metrics``, ``wait_until_finished``,
+    ``close``) using the same best_fn/best_mode policy orbax does, so
+    the tests stay decoupled from disk I/O but still validate the
+    branching that depends on orbax's native best tracking.
+    """
+
+    def __init__(self, directory, options):
+        self._dir = directory
+        self._best_fn = options.best_fn
+        self._best_mode = options.best_mode
+        self._steps: list[int] = []
+        self._metrics: dict[int, dict] = {}
+        self.wait_calls = 0
+        self.close_calls = 0
+        self.save_args: list[dict] = []
+
+    def save(self, step, args, metrics=None):
+        # Match orbax: silently reject duplicate or backward steps.
+        if self._steps and step <= self._steps[-1]:
+            self.save_args.append(
+                {"step": step, "args": args, "metrics": metrics, "ok": False}
+            )
+            return False
+        self._steps.append(step)
+        if metrics is not None:
+            self._metrics[step] = dict(metrics)
+        self.save_args.append(
+            {"step": step, "args": args, "metrics": metrics, "ok": True}
+        )
+        return True
+
+    def best_step(self):
+        scored = [(self._best_fn(m), s) for s, m in self._metrics.items()]
+        if not scored:
+            return None
+        chosen = (
+            max(scored, key=lambda x: x[0])
+            if self._best_mode == "max"
+            else min(scored, key=lambda x: x[0])
+        )
+        return chosen[1]
+
+    def metrics(self, step):
+        return self._metrics.get(step)
+
+    def latest_step(self):
+        return self._steps[-1] if self._steps else None
+
+    def wait_until_finished(self):
+        self.wait_calls += 1
+
+    def close(self):
+        self.close_calls += 1
+
+
+def _make(tmp_path, cfg=None, name="DummyEstimator"):
+    """Build a Checkpointer backed by a ``_FakeManager`` instance."""
+    model = type(name, (), {})()
+    fakes: list[_FakeManager] = []
+
+    def _ctor(directory, options=None):
+        fake = _FakeManager(directory, options)
+        fakes.append(fake)
+        return fake
+
+    with (
+        patch("flowgym.checkpointing.ocp.CheckpointManager", side_effect=_ctor),
+        patch(
+            "flowgym.checkpointing.build_save_args", return_value=MagicMock()
+        ),
+        patch("flowgym.checkpointing.logger") as logger_mock,
+    ):
+        ckpt = Checkpointer(
+            out_dir=tmp_path, model=model, sampler=None, config=cfg
+        )
+        # Hand the test the live fake so it can introspect what was saved.
+        yield ckpt, fakes[0], logger_mock
+
+
+# ---------------------------------------------------------------------------
+# CheckpointConfig validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"wandb_upload": "evrey"},
+        {"wandb_upload": ""},
+        {"keep": 0},
+        {"keep": -1},
+        {"keep": 1.5},  # pyright: ignore[reportArgumentType]
+        {"metric_key": ""},
+    ],
+)
+def test_checkpoint_config_rejects_bad_values(kwargs):
+    with pytest.raises(ValueError):
+        CheckpointConfig(**kwargs)
+
+
+def test_from_configs_reads_model_block_with_legacy_fallback():
+    cfg = CheckpointConfig.from_configs(
+        model_config={"checkpoint": {"wandb_upload": "every", "keep": 5}},
+        dataset_config={"save_only_best": True},
+    )
+    assert cfg.wandb_upload == "every"
+    assert cfg.keep == 5
+    assert cfg.save_only_best is True
+
+
+def test_from_configs_model_block_overrides_legacy():
+    cfg = CheckpointConfig.from_configs(
+        model_config={"checkpoint": {"save_only_best": False}},
+        dataset_config={"save_only_best": True},
+    )
+    assert cfg.save_only_best is False
+
+
+# ---------------------------------------------------------------------------
+# Native best tracking via orbax (best_fn + best_mode)
+# ---------------------------------------------------------------------------
+
+
+def test_best_metric_none_before_any_save(tmp_path):
+    for ckpt, _, _ in _make(tmp_path):
+        assert ckpt.best_metric is None
+        assert ckpt.best_step is None
+
+
+def test_best_step_tracks_lower_is_better(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 10, {"mean_error": 0.5})
+        ckpt.on_validation(MagicMock(), 20, {"mean_error": 0.6})
+        ckpt.on_validation(MagicMock(), 30, {"mean_error": 0.3})
+        assert ckpt.best_step == 30
+        assert ckpt.best_metric == pytest.approx(0.3)
+        # All three saves landed with the expected metric keys.
+        recorded = [c["metrics"] for c in fake.save_args if c["ok"]]
+        assert [m["mean_error"] for m in recorded] == [0.5, 0.6, 0.3]
+
+
+def test_best_step_tracks_higher_is_better(tmp_path):
+    cfg = CheckpointConfig(
+        wandb_upload="every", metric_key="accuracy", higher_is_better=True
+    )
+    for ckpt, _, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 10, {"accuracy": 0.8})
+        ckpt.on_validation(MagicMock(), 20, {"accuracy": 0.7})
+        ckpt.on_validation(MagicMock(), 30, {"accuracy": 0.9})
+        assert ckpt.best_step == 30
+        assert ckpt.best_metric == pytest.approx(0.9)
+
+
+def test_on_validation_ignores_missing_or_nonfinite_metric(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        assert ckpt.on_validation(MagicMock(), 5, {}) is None
+        assert (
+            ckpt.on_validation(MagicMock(), 6, {"mean_error": float("nan")})
+            is None
+        )
+        # Neither call reached orbax.
+        assert all(not c["ok"] for c in fake.save_args) or not fake.save_args
+
+
+# ---------------------------------------------------------------------------
+# wandb_upload dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_on_validation_never_does_not_save_or_upload(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="never")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        out = ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.3})
+        assert out is None
+        assert fake.save_args == []
+        logger_mock.artifact.assert_not_called()
+
+
+def test_on_validation_best_uploads_only_on_improvement(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="best")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        assert len(fake.save_args) == 1
+        assert logger_mock.artifact.call_count == 1
+        assert "best" in logger_mock.artifact.call_args.args[0]["aliases"]
+
+        ckpt.on_validation(MagicMock(), 10, {"mean_error": 0.6})
+        assert len(fake.save_args) == 1
+        assert logger_mock.artifact.call_count == 1
+
+        ckpt.on_validation(MagicMock(), 15, {"mean_error": 0.2})
+        assert len(fake.save_args) == 2
+        assert logger_mock.artifact.call_count == 2
+
+
+def test_on_validation_every_uploads_at_each_call(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, _, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        ckpt.on_validation(MagicMock(), 10, {"mean_error": 0.6})
+        ckpt.on_validation(MagicMock(), 15, {"mean_error": 0.4})
+        assert logger_mock.artifact.call_count == 3
+        # Best alias migrates with orbax's view of the best.
+        step5 = logger_mock.artifact.call_args_list[0].args[0]["aliases"]
+        step10 = logger_mock.artifact.call_args_list[1].args[0]["aliases"]
+        step15 = logger_mock.artifact.call_args_list[2].args[0]["aliases"]
+        assert "best" in step5 and "latest" in step5
+        assert "latest" in step10 and "best" not in step10
+        assert "best" in step15 and "latest" in step15
+
+
+def test_artifact_payload_uses_model_class_name(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, _, logger_mock in _make(tmp_path, cfg=cfg, name="MyEstimator"):
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        payload = logger_mock.artifact.call_args.args[0]
+        assert payload["name"] == "MyEstimator_checkpoint"
+        assert payload["type"] == "checkpoint"
+        assert "path" in payload
+
+
+# ---------------------------------------------------------------------------
+# Periodic / final saves
+# ---------------------------------------------------------------------------
+
+
+def test_save_periodic_unconditional(tmp_path):
+    cfg = CheckpointConfig(save_only_best=False)
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.save_periodic(MagicMock(), step=10)
+        ckpt.save_periodic(MagicMock(), step=20)
+        assert len(fake.save_args) == 2
+        logger_mock.artifact.assert_not_called()
+
+
+def test_save_periodic_only_after_new_best(tmp_path):
+    cfg = CheckpointConfig(save_only_best=True)
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        # No validation yet → skip.
+        assert ckpt.save_periodic(MagicMock(), step=10) is None
+        assert fake.save_args == []
+        # First validation flips the latch (no save here because
+        # wandb_upload=never).
+        ckpt.on_validation(
+            MagicMock(), step=15, val_metrics={"mean_error": 0.5}
+        )
+        assert ckpt.save_periodic(MagicMock(), step=20) is not None
+        assert len(fake.save_args) == 1
+        # Second periodic call without a new best → skip.
+        assert ckpt.save_periodic(MagicMock(), step=30) is None
+        assert len(fake.save_args) == 1
+        # New best → next periodic save fires.
+        ckpt.on_validation(
+            MagicMock(), step=35, val_metrics={"mean_error": 0.3}
+        )
+        assert ckpt.save_periodic(MagicMock(), step=40) is not None
+        assert len(fake.save_args) == 2
+
+
+def test_save_only_best_with_wandb_never_skips_regressions(tmp_path):
+    """Regression for codex P1 on #158.
+
+    With ``wandb_upload="never"`` and ``save_only_best=True``,
+    validation events don't reach orbax (no save → no metrics on
+    disk). Without a local best-metric tracker, every subsequent
+    validation would compare against ``None``, register as a "new
+    best", and trip the latch — so periodic saves would fire on
+    every cycle instead of only on real improvements.
+
+    Sequence: first observation 0.5 (best), regression 0.6, regression
+    0.7 — only the first periodic save should fire.
+    """
+    cfg = CheckpointConfig(save_only_best=True, wandb_upload="never")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        assert ckpt.save_periodic(MagicMock(), 10) is not None
+        assert len(fake.save_args) == 1
+
+        # Regression: no new best, latch must stay down.
+        ckpt.on_validation(MagicMock(), 15, {"mean_error": 0.6})
+        assert ckpt.save_periodic(MagicMock(), 20) is None
+        assert len(fake.save_args) == 1
+
+        # Another regression: still no save.
+        ckpt.on_validation(MagicMock(), 25, {"mean_error": 0.7})
+        assert ckpt.save_periodic(MagicMock(), 30) is None
+        assert len(fake.save_args) == 1
+
+        # Genuine improvement: save fires again.
+        ckpt.on_validation(MagicMock(), 35, {"mean_error": 0.4})
+        assert ckpt.save_periodic(MagicMock(), 40) is not None
+        assert len(fake.save_args) == 2
+
+
+def test_save_periodic_carries_latest_observed_metrics(tmp_path):
+    """Periodic saves attach the most recent validation metrics.
+
+    Without this, orbax's on-disk best tracking would diverge from
+    our local tracker (the in-memory ``_seen_best`` would say
+    "metric=0.3 is the best" while ``best_step`` would point at a
+    metricless save and the stored ``metrics`` for it would be
+    empty).
+    """
+    cfg = CheckpointConfig(save_only_best=False)
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.3})
+        ckpt.save_periodic(MagicMock(), 10)
+        assert fake.save_args[-1]["metrics"] == {"mean_error": 0.3}
+
+
+def test_best_metric_survives_resume(tmp_path):
+    """A fresh Checkpointer on the same dir bootstraps ``best_metric``
+    from orbax's persisted metrics.
+
+    Exercises the real ``__init__`` bootstrap path: the underlying
+    manager is pre-seeded with prior-run state *before* the
+    Checkpointer is constructed, so the assertion observes what the
+    constructor read out of orbax — not a value the test wrote in
+    after the fact.
+    """
+    cfg = CheckpointConfig(wandb_upload="every")
+    model = type("DummyEstimator", (), {})()
+    fakes: list[_FakeManager] = []
+
+    def _ctor(directory, options=None):
+        fake = _FakeManager(directory, options)
+        # Simulate a prior run that already wrote two checkpoints.
+        fake._steps = [5, 10]
+        fake._metrics = {5: {"mean_error": 0.5}, 10: {"mean_error": 0.2}}
+        fakes.append(fake)
+        return fake
+
+    with (
+        patch("flowgym.checkpointing.ocp.CheckpointManager", side_effect=_ctor),
+        patch(
+            "flowgym.checkpointing.build_save_args", return_value=MagicMock()
+        ),
+        patch("flowgym.checkpointing.logger"),
+    ):
+        ckpt2 = Checkpointer(
+            out_dir=tmp_path, model=model, sampler=None, config=cfg
+        )
+    # Constructor read orbax's persisted best (step 10, mean_error=0.2)
+    # and seeded ``_seen_best`` from it — without the test touching it.
+    assert ckpt2.best_step == 10
+    assert ckpt2.best_metric == pytest.approx(0.2)
+
+
+def test_on_validation_save_clears_unsaved_best_latch(tmp_path):
+    """A save through ``on_validation`` must clear the unsaved-best flag.
+
+    Same-step ``save_periodic`` right after would otherwise re-fire and
+    orbax would reject the duplicate-step write.
+    """
+    cfg = CheckpointConfig(wandb_upload="best", save_only_best=True)
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 100, {"mean_error": 0.5})
+        assert len(fake.save_args) == 1
+        assert ckpt.save_periodic(MagicMock(), 100) is None
+        assert len(fake.save_args) == 1
+
+
+def test_save_final_always_writes_and_uploads_when_enabled(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="best")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.save_final(MagicMock(), step=99)
+        assert len(fake.save_args) == 1
+        assert logger_mock.artifact.call_count == 1
+        assert "final" in logger_mock.artifact.call_args.args[0]["aliases"]
+
+
+def test_save_final_no_upload_when_disabled(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="never")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.save_final(MagicMock(), step=99)
+        assert len(fake.save_args) == 1
+        logger_mock.artifact.assert_not_called()
+
+
+def test_save_final_forwards_val_metrics_to_orbax(tmp_path):
+    """Regression for Copilot #158 review.
+
+    If the final evaluation is the best, orbax must receive its
+    metrics so ``best_step`` migrates to the final checkpoint;
+    otherwise the ``best`` artifact alias would stay stuck on a
+    mid-training checkpoint with worse metrics.
+    """
+    cfg = CheckpointConfig(wandb_upload="best")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 10, {"mean_error": 0.5})
+        ckpt.save_final(MagicMock(), step=99, val_metrics={"mean_error": 0.2})
+        # Final save carries the final-eval metric, not metrics=None.
+        assert fake.save_args[-1]["metrics"] == {"mean_error": 0.2}
+        # Best now points at the final step.
+        assert ckpt.best_step == 99
+        assert ckpt.best_metric == pytest.approx(0.2)
+
+
+def test_save_final_falls_back_to_last_observed(tmp_path):
+    """When no val_metrics is passed, save_final reuses the most
+    recent validation observation so orbax's best tracker stays
+    consistent with the in-memory tracker."""
+    cfg = CheckpointConfig(wandb_upload="never")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 10, {"mean_error": 0.3})
+        ckpt.save_final(MagicMock(), step=99)
+        assert fake.save_args[-1]["metrics"] == {"mean_error": 0.3}
+
+
+def test_orbax_rejects_duplicate_step_returns_none(tmp_path):
+    """A backward ``save`` that reaches orbax reports None and warns.
+
+    Uses ``save_final`` for the second call so the in-loop same-step
+    guard on ``save_periodic`` doesn't short-circuit before orbax.
+    """
+    cfg = CheckpointConfig()
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        assert ckpt.save_periodic(MagicMock(), step=10) is not None
+        # ``save_final`` does not guard same-step so the call reaches
+        # the fake and exercises orbax's duplicate-step rejection.
+        assert ckpt.save_final(MagicMock(), step=10) is None
+        assert len(fake.save_args) == 2
+        assert fake.save_args[1]["ok"] is False
+        logger_mock.warning.assert_called()
+
+
+def test_save_periodic_same_step_after_on_validation_silently_skips(tmp_path):
+    """Regression for antonioterpin #158 review #4.
+
+    When ``val_interval == save_every`` (a common 100/100 shape),
+    ``on_validation`` may have already saved this exact step. Without a
+    guard, the follow-up ``save_periodic`` reaches orbax, is rejected
+    as a duplicate, and emits a WARNING every coincident interval.
+    The guard short-circuits silently.
+    """
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        ckpt.on_validation(MagicMock(), 100, {"mean_error": 0.5})
+        assert len(fake.save_args) == 1
+        # Same step: must short-circuit BEFORE reaching orbax, so the
+        # warning path stays quiet.
+        assert ckpt.save_periodic(MagicMock(), step=100) is None
+        assert len(fake.save_args) == 1
+        logger_mock.warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: close() / context manager / async safety
+# ---------------------------------------------------------------------------
+
+
+def test_close_waits_then_closes_underlying_manager(tmp_path):
+    for ckpt, fake, _ in _make(tmp_path):
+        assert fake.wait_calls == 0 and fake.close_calls == 0
+        ckpt.close()
+        assert fake.wait_calls == 1
+        assert fake.close_calls == 1
+
+
+def test_close_is_idempotent(tmp_path):
+    for ckpt, fake, _ in _make(tmp_path):
+        ckpt.close()
+        ckpt.close()
+        assert fake.wait_calls == 1
+        assert fake.close_calls == 1
+
+
+def test_context_manager_closes_on_normal_exit(tmp_path):
+    for ckpt, fake, _ in _make(tmp_path):
+        with ckpt:
+            pass
+        assert fake.wait_calls == 1
+        assert fake.close_calls == 1
+
+
+def test_context_manager_closes_on_exception(tmp_path):
+    for ckpt, fake, _ in _make(tmp_path):
+        with pytest.raises(RuntimeError):
+            with ckpt:
+                raise RuntimeError("boom")
+        assert fake.wait_calls == 1
+        assert fake.close_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Manager construction
+# ---------------------------------------------------------------------------
+
+
+def test_manager_options_reflect_config(tmp_path):
+    cfg = CheckpointConfig(keep=7, metric_key="loss", higher_is_better=False)
+    for _, fake, _ in _make(tmp_path, cfg=cfg):
+        # _FakeManager stashes the options it was constructed with.
+        # Best-mode and best_fn semantics propagate.
+        assert fake._best_mode == "min"
+        # The best_fn pulls our metric_key.
+        assert fake._best_fn({"loss": 0.42}) == pytest.approx(0.42)
+
+
+def test_manager_options_higher_is_better_sets_max(tmp_path):
+    cfg = CheckpointConfig(
+        wandb_upload="every", metric_key="acc", higher_is_better=True
+    )
+    for _, fake, _ in _make(tmp_path, cfg=cfg):
+        assert fake._best_mode == "max"
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def _install_order_probes(fake, logger_mock):
+    """Wire instrumented ``wait_until_finished`` + ``logger.artifact``.
+
+    Returns a list that records the call order ``"wait"``/``"artifact"``
+    so tests can assert the barrier fires before the upload.
+    """
+    call_order: list[str] = []
+
+    def _wait(_fake=fake, _order=call_order):
+        _order.append("wait")
+        _fake.wait_calls += 1
+
+    def _artifact(*args, _order=call_order, **kwargs):
+        _order.append("artifact")
+
+    fake.wait_until_finished = _wait
+    logger_mock.artifact.side_effect = _artifact
+    return call_order
+
+
+def test_on_validation_waits_for_save_before_upload(tmp_path):
+    """Regression for antonioterpin #158 review #1.
+
+    Saves run async (``enable_async_checkpointing=True``), so
+    ``self._mngr.save`` returns before ``<step>/`` is finalized. W&B
+    snapshots the directory eagerly via ``logger.artifact``; without a
+    barrier we'd upload an incomplete (or not-yet-present) directory.
+    The barrier must precede the upload.
+    """
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        call_order = _install_order_probes(fake, logger_mock)
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        assert call_order == ["wait", "artifact"]
+
+
+def test_save_final_waits_for_save_before_upload(tmp_path):
+    """Same async-vs-upload race as ``on_validation``; ``save_final``
+    must also flush before uploading the ``final`` artifact."""
+    cfg = CheckpointConfig(wandb_upload="best")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        call_order = _install_order_probes(fake, logger_mock)
+        ckpt.save_final(MagicMock(), step=99)
+        assert call_order == ["wait", "artifact"]
+
+
+def test_save_final_no_upload_skips_wait_barrier(tmp_path):
+    """When uploads are disabled, ``save_final`` need not wait — the
+    upload barrier is the only reason to block synchronously here.
+    """
+    cfg = CheckpointConfig(wandb_upload="never")
+    for ckpt, fake, _ in _make(tmp_path, cfg=cfg):
+        before = fake.wait_calls
+        ckpt.save_final(MagicMock(), step=99)
+        # Only the eventual close() should call wait_until_finished.
+        assert fake.wait_calls == before
+
+
+def test_upload_failure_does_not_raise(tmp_path):
+    cfg = CheckpointConfig(wandb_upload="every")
+    for ckpt, fake, logger_mock in _make(tmp_path, cfg=cfg):
+        logger_mock.artifact.side_effect = RuntimeError("network down")
+        # Should swallow + warn so training continues.
+        ckpt.on_validation(MagicMock(), 5, {"mean_error": 0.5})
+        assert len(fake.save_args) == 1
+        logger_mock.warning.assert_called()

--- a/tests/unit/training/test_synthpix_compat.py
+++ b/tests/unit/training/test_synthpix_compat.py
@@ -1,0 +1,93 @@
+"""Tests for the synthpix NaN-shape compat shim."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from flowgym._synthpix_compat import (
+    _has_nan_shape,
+    _scrub_nan_placeholders,
+    install_restore_state_shim,
+)
+
+
+def test_has_nan_shape_detects_nan_dim():
+    """``_has_nan_shape`` flags ShapeDtypeStructs with NaN in their shape."""
+    bad = jax.ShapeDtypeStruct((np.nan,), jnp.uint8)
+    good = jax.ShapeDtypeStruct((4,), jnp.uint8)
+    assert _has_nan_shape(bad), "NaN-dim ShapeDtypeStruct must be detected"
+    assert not _has_nan_shape(good), (
+        "Integer-dim ShapeDtypeStruct must not be flagged"
+    )
+    assert not _has_nan_shape(None), "None passes through unflagged"
+    assert not _has_nan_shape(jnp.zeros((2, 3))), (
+        "Real arrays must not be flagged"
+    )
+
+
+def test_scrub_replaces_nan_placeholders_with_none():
+    """``_scrub_nan_placeholders`` rewrites NaN-shape leaves to None."""
+    state = {
+        "files_scheduler": jax.ShapeDtypeStruct((np.nan,), jnp.uint8),
+        "current_flows": jax.ShapeDtypeStruct((1, 32, 32, 2), jnp.float32),
+        "batches_generated": 0,
+        "other": jnp.array([1.0, 2.0]),
+    }
+    out = _scrub_nan_placeholders(state)
+    assert out is state, "Should mutate in place and return same dict"
+    assert state["files_scheduler"] is None, (
+        "NaN-shape placeholder must be replaced with None"
+    )
+    assert isinstance(state["current_flows"], jax.ShapeDtypeStruct), (
+        "Integer-shape placeholders must be left untouched"
+    )
+    assert state["batches_generated"] == 0, "Scalars must be untouched"
+    np.testing.assert_array_equal(state["other"], np.array([1.0, 2.0]))
+
+
+def test_scrub_is_noop_on_clean_state():
+    """A state dict without any NaN placeholders is returned unchanged."""
+    state = {
+        "step": 5,
+        "rng": jnp.array([0, 1], dtype=jnp.uint32),
+        "current_flows": jax.ShapeDtypeStruct((1, 32, 32, 2), jnp.float32),
+    }
+    before = dict(state)
+    _scrub_nan_placeholders(state)
+    assert state == before, "Clean state must be unchanged after scrubbing"
+
+
+def test_install_shim_is_idempotent():
+    """Installing the shim twice patches at most once."""
+    first = install_restore_state_shim()
+    second = install_restore_state_shim()
+    # First call may have already been performed by ``flowgym.make`` at
+    # import time; we only assert that the second call is a no-op.
+    assert second is False, (
+        "Idempotent install: a repeat call must report False"
+    )
+    # If the first call here actually patched, it returned True; if a
+    # previous import already patched, both are False — both shapes are
+    # valid, but we did not accidentally re-patch.
+    assert first in (True, False)
+
+
+def test_shim_marks_patched_property():
+    """After installation, the patched ``restore_state`` carries the marker.
+
+    Verifying the marker (rather than driving the property through a
+    full sampler) keeps the test independent of synthpix's other
+    field substitutions, which require a fully-constructed sampler.
+    """
+    install_restore_state_shim()
+    from synthpix.sampler.synthetic import (
+        SyntheticImageSampler,
+    )
+
+    prop = SyntheticImageSampler.__dict__["restore_state"]
+    assert isinstance(prop, property), "restore_state must remain a property"
+    assert getattr(prop.fget, "_flowgym_nan_shape_shim", False), (
+        "Patched fget must carry the idempotency marker"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -743,7 +743,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "scikit-image", specifier = ">=0.20.0" },
     { name = "snowballstemmer" },
-    { name = "synthpix", specifier = ">=0.2.0" },
+    { name = "synthpix", git = "https://github.com/antonioterpin/synthpix.git?rev=8cfbd7d" },
     { name = "wandb", specifier = ">=0.16,<1.0" },
 ]
 dev-cuda12 = [
@@ -758,11 +758,11 @@ dev-cuda12 = [
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "scikit-image", specifier = ">=0.20.0" },
     { name = "snowballstemmer" },
-    { name = "synthpix", specifier = ">=0.2.0" },
-    { name = "synthpix", extras = ["cuda12"], specifier = ">=0.2.0" },
+    { name = "synthpix", git = "https://github.com/antonioterpin/synthpix.git?rev=8cfbd7d" },
+    { name = "synthpix", extras = ["cuda12"], git = "https://github.com/antonioterpin/synthpix.git?rev=8cfbd7d" },
     { name = "wandb", specifier = ">=0.16,<1.0" },
 ]
-synthpix-cuda12 = [{ name = "synthpix", extras = ["cuda12"], specifier = ">=0.2.0" }]
+synthpix-cuda12 = [{ name = "synthpix", extras = ["cuda12"], git = "https://github.com/antonioterpin/synthpix.git?rev=8cfbd7d" }]
 
 [[package]]
 name = "fonttools"
@@ -3301,8 +3301,8 @@ wheels = [
 
 [[package]]
 name = "synthpix"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.2"
+source = { git = "https://github.com/antonioterpin/synthpix.git?rev=8cfbd7d#8cfbd7d3538305e95b6084e85c14f9f0430e047b" }
 dependencies = [
     { name = "gdown" },
     { name = "grain" },
@@ -3314,10 +3314,6 @@ dependencies = [
     { name = "robo-goggles" },
     { name = "ruamel-yaml" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/a5/68ba19a1a61202828a40b1ef82a11e56ab2ce8bf603c9f55d759a8d27eb7/synthpix-0.2.0.tar.gz", hash = "sha256:ff9fd17106a7290eb9695dc3fffb1d7954d74c11ded7c096a24aac58d69b1f28", size = 116597, upload-time = "2026-05-24T15:35:02.047Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/64/28c44870c99f12e00e1a86173327287b6e35c2abc385bb7143f09f5e6707/synthpix-0.2.0-py3-none-any.whl", hash = "sha256:f7d57b4a747819bacca0fc6bf8ee66cfd08018997a6bf63f07dcc5fc4aa29d8d", size = 103746, upload-time = "2026-05-24T15:35:00.741Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Ports the checkpointing stack from the private `fluids-estimation` dev (PRs #157–161) onto the renamed make API:

- **`flowgym/checkpointing.py`** — `Checkpointer` context manager with a single long-lived orbax `CheckpointManager`, native best-metric tracking, and `best`/`every`/`never` W&B upload modes (`save_periodic` / `on_validation` / `save_final`).
- **`flowgym/checkpoint_source.py`** — resolve `wandb://[entity/]project/name[:alias][/subpath]` artifact URIs to a local path for resume.
- **`flowgym/_synthpix_compat.py`** — scrub synthpix's NaN-shape restore placeholder that orbax 0.11+ rejects; installed once at `make` import.
- **`make.py`** — `build_save_args` + wandb-aware `load_from` resolution.
- **`train.py` / `train_supervised.py` / `main.py`** — route all saves through `Checkpointer`. Trainer-function params keep their existing `estimator` naming (the trainer-param rename was intentionally kept out of scope; only the make API was renamed in the stacked PR).
- **deps** — pin synthpix to the git rev the NaN-scrub targets; `uv.lock` regenerated.

> ⚠️ **Stacked on #49** (the estimator→model make API rename). Base will retarget to `dev` once #49 merges.

## Test plan
- [x] New-module unit tests: `test_checkpointer.py`, `test_checkpoint_source.py`, `test_synthpix_compat.py` — 70 passed
- [x] All checkpoint unit tests (incl. `test_checkpointing`, `test_partial`, `test_sampler`) — 80 passed
- [x] Integration: `test_full_integration.py`, `test_integrated_checkpointing.py`, `test_trainable_state_integration.py` — 19 passed (integration tests patch `Checkpointer` via an in-process fake)
- [x] `pre-commit` (ruff, ruff-format, pydoclint, basedpyright) passes on all changed files