### PR TITLE
feat(open_piv): port sig2noise_ratio from openpiv to JAX

### DIFF
--- a/src/flowgym/flow/open_piv/process.py
+++ b/src/flowgym/flow/open_piv/process.py
@@ -1,5 +1,7 @@
 """Module for OpenPIV processing in JAX."""
 
+from typing import overload
+
 import jax
 import jax.numpy as jnp
 from jax import lax
@@ -8,13 +10,39 @@ from flowgym.flow.process import img_resize
 from flowgym.utils import DEBUG
 
 
+@overload
 def extended_search_area_piv(
     img1: jnp.ndarray,
     img2: jnp.ndarray,
     window_size: int,
     search_area_size: int,
     overlap: int,
-) -> jnp.ndarray:
+    sig2noise_method: None = None,
+    width: int = 2,
+) -> jnp.ndarray: ...
+
+
+@overload
+def extended_search_area_piv(
+    img1: jnp.ndarray,
+    img2: jnp.ndarray,
+    window_size: int,
+    search_area_size: int,
+    overlap: int,
+    sig2noise_method: str,
+    width: int = 2,
+) -> tuple[jnp.ndarray, jnp.ndarray]: ...
+
+
+def extended_search_area_piv(
+    img1: jnp.ndarray,
+    img2: jnp.ndarray,
+    window_size: int,
+    search_area_size: int,
+    overlap: int,
+    sig2noise_method: str | None = None,
+    width: int = 2,
+) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray]:
     """Batched PIV cross-correlation algorithm.
 
     JAX implementation of the openpiv extended search area PIV algorithm.
@@ -26,9 +54,17 @@ def extended_search_area_piv(
         window_size: Size of the interrogation window.
         search_area_size: Size of the search area.
         overlap: Overlap between interrogation windows.
+        sig2noise_method: Optional signal-to-noise method ("peak2peak" or
+            "peak2mean"). When set, the per-window signal-to-noise ratio is
+            returned alongside the displacement field, mirroring the third
+            output of the openpiv reference pipeline.
+        width: Half-size of the exclusion box around the first correlation
+            peak; only used when ``sig2noise_method == "peak2peak"``.
 
     Returns:
-        Displacement field of shape (batch_size, n_rows, n_cols, 2).
+        Displacement field of shape (batch_size, n_rows, n_cols, 2). If
+        ``sig2noise_method`` is set, a tuple of the displacement field and
+        the signal-to-noise ratios of shape (batch_size, n_rows, n_cols).
     """
     # Validate inputs
     if DEBUG:
@@ -103,7 +139,12 @@ def extended_search_area_piv(
     disp_vy = disp_vy.reshape(img1.shape[0], n_rows, n_cols)
 
     # final displacement field of shape (batch, n_rows, n_cols, 2)
-    return jnp.stack((disp_vx, disp_vy), axis=-1)
+    flow = jnp.stack((disp_vx, disp_vy), axis=-1)
+
+    if sig2noise_method is not None:
+        s2n = sig2noise_ratio(corr, sig2noise_method, width)
+        return flow, s2n.reshape(img1.shape[0], n_rows, n_cols)
+    return flow
 
 
 def get_field_shape(
@@ -198,6 +239,126 @@ def find_all_first_peaks(corr: jnp.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
     peaks_i = ind // corr_width
     peaks_j = ind % corr_width
     return peaks_i, peaks_j
+
+
+def find_all_second_peaks(
+    corr: jnp.ndarray, width: int = 2
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Find the second-highest peak outside a box around the first peak.
+
+    Mirrors ``openpiv.pyprocess.find_all_second_peaks``: a square region of
+    half-size ``width`` centred on the first peak (clipped at the map
+    borders, exactly like the reference's clamped slices) is excluded, and
+    the highest remaining value is the second peak.
+
+    Args:
+        corr: Batched correlation maps (..., height, width).
+        width: Half-size of the exclusion box around the first peak.
+
+    Returns:
+        Tuple ``(peaks_i, peaks_j, peaks_value)`` of the row indices, column
+        indices and heights of the second peaks, each of shape
+        ``corr.shape[:-2]``.
+    """
+    if DEBUG:
+        assert corr.ndim >= 2, (
+            f"Correlation must be (..., height, width), instead {corr.shape}"
+        )
+        assert width > 0, "Width must be positive."
+
+    H, W = corr.shape[-2:]
+    flat = corr.reshape(*corr.shape[:-2], -1)
+    ind1 = jnp.argmax(flat, axis=-1)
+    peaks1_i, peaks1_j = ind1 // W, ind1 % W
+
+    # Exclude the (2 * width + 1)^2 box around the first peak. The reference
+    # clamps the box slices at the map borders, which is exactly what the
+    # |index - peak| <= width mask reproduces.
+    rows = jnp.arange(H)
+    cols = jnp.arange(W)
+    box = (jnp.abs(rows[:, None] - peaks1_i[..., None, None]) <= width) & (
+        jnp.abs(cols[None, :] - peaks1_j[..., None, None]) <= width
+    )
+    masked = jnp.where(box, -jnp.inf, corr)
+
+    flat2 = masked.reshape(*corr.shape[:-2], -1)
+    ind2 = jnp.argmax(flat2, axis=-1)
+    peaks2 = jnp.max(flat2, axis=-1)
+    return ind2 // W, ind2 % W, peaks2
+
+
+def sig2noise_ratio(
+    corr: jnp.ndarray,
+    sig2noise_method: str = "peak2peak",
+    width: int = 2,
+) -> jnp.ndarray:
+    """Compute the signal-to-noise ratio of batched correlation maps.
+
+    JAX port of ``openpiv.pyprocess.vectorized_sig2noise_ratio``. The ratio
+    is the first-peak height over the second-peak height ("peak2peak") or
+    over the absolute mean of the correlation map ("peak2mean"), and is a
+    per-window measure of the matching quality.
+
+    Windows with a weak first peak (< 1e-3), a first peak on the map border
+    and — for "peak2peak" — a weak or border second peak are flagged and
+    their ratio is set to 0. Note that the reference builds this exact flag
+    but never applies it (``flag is True`` indexes with a constant ``False``
+    and selects nothing in openpiv 0.25.4); this port applies it as
+    intended, matching the loop-based ``pyprocess.sig2noise_ratio``
+    semantics on the shared rules.
+
+    Args:
+        corr: Batched correlation maps (..., height, width).
+        sig2noise_method: Either "peak2peak" or "peak2mean".
+        width: Half-size of the exclusion box around the first peak; only
+            used when ``sig2noise_method == "peak2peak"``.
+
+    Returns:
+        Signal-to-noise ratios of shape ``corr.shape[:-2]``, with flagged
+        windows set to 0.
+
+    Raises:
+        ValueError: If ``sig2noise_method`` is not supported.
+    """
+    if sig2noise_method not in ("peak2peak", "peak2mean"):
+        raise ValueError(f"sig2noise_method not supported: {sig2noise_method}")
+    if DEBUG:
+        assert corr.ndim >= 2, (
+            f"Correlation must be (..., height, width), instead {corr.shape}"
+        )
+
+    H, W = corr.shape[-2:]
+    flat = corr.reshape(*corr.shape[:-2], -1)
+    ind1 = jnp.argmax(flat, axis=-1)
+    peaks1_i, peaks1_j = ind1 // W, ind1 % W
+    peaks1 = jnp.max(flat, axis=-1)
+
+    flag = (
+        (peaks1 < 1e-3)
+        | (peaks1_i == 0)
+        | (peaks1_i == H - 1)
+        | (peaks1_j == 0)
+        | (peaks1_j == W - 1)
+    )
+
+    if sig2noise_method == "peak2peak":
+        peaks2_i, peaks2_j, peaks2 = find_all_second_peaks(corr, width)
+        flag = (
+            flag
+            | (peaks2 < 1e-3)
+            | (peaks2_i == 0)
+            | (peaks2_i == H - 1)
+            | (peaks2_j == 0)
+            | (peaks2_j == W - 1)
+        )
+        noise = peaks2
+    else:
+        noise = jnp.abs(jnp.nanmean(corr, axis=(-2, -1)))
+
+    # Reference: np.divide(..., out=zeros, where=noise > 0). The guarded
+    # denominator keeps the division NaN-free under jit.
+    ratio = jnp.where(noise > 0, peaks1 / jnp.where(noise > 0, noise, 1.0), 0.0)
+    return jnp.where(flag, 0.0, ratio)
 
 
 def subpixel_displacement(

--- a/tests/unit/flow/test_openpiv_jax.py
+++ b/tests/unit/flow/test_openpiv_jax.py
@@ -11,11 +11,13 @@ import pytest
 from openpiv import pyprocess
 
 from flowgym.flow.open_piv.process import (
+    extended_search_area_piv,
     fft_correlate_images,
     find_all_first_peaks,
     get_field_shape,
     get_rect_coordinates,
     normalize_intensity,
+    sig2noise_ratio,
     sliding_window_array,
     subpixel_displacement,
     upsample_flow,
@@ -303,3 +305,46 @@ def test_find_all_first_peaks(random_images):
 
         np.testing.assert_allclose(pi, peaks_i_gt, rtol=1e-6)
         np.testing.assert_allclose(pj, peaks_j_gt, rtol=1e-6)
+
+
+def test_sig2noise_batched_leading_dims(random_images):
+    """sig2noise_ratio vectorizes over arbitrary leading dimensions."""
+    img1, img2 = random_images
+    aa = sliding_window_array(
+        jnp.asarray(img1, dtype=jnp.float32), (32, 32), (16, 16)
+    )
+    bb = sliding_window_array(
+        jnp.asarray(img2, dtype=jnp.float32), (32, 32), (16, 16)
+    )
+    corr = fft_correlate_images(aa, bb)  # (batch, n_windows, H, W)
+
+    for method in ("peak2peak", "peak2mean"):
+        out = np.asarray(sig2noise_ratio(corr, sig2noise_method=method))
+        flat = np.asarray(
+            sig2noise_ratio(
+                corr.reshape(-1, *corr.shape[-2:]), sig2noise_method=method
+            )
+        )
+        assert out.shape == corr.shape[:-2]
+        np.testing.assert_allclose(out.reshape(-1), flat, rtol=1e-6)
+
+
+def test_sig2noise_invalid_method_raises():
+    """An unknown method raises ValueError, mirroring the reference."""
+    corr = jnp.ones((1, 8, 8))
+    with pytest.raises(ValueError, match="sig2noise_method"):
+        sig2noise_ratio(corr, sig2noise_method="peak2median")
+
+
+def test_extended_search_area_piv_flow_only_return(random_images):
+    """Omitting sig2noise_method preserves the original single-array API."""
+    img1, img2 = random_images
+    flow = extended_search_area_piv(
+        jnp.asarray(img1, dtype=jnp.float32),
+        jnp.asarray(img2, dtype=jnp.float32),
+        window_size=32,
+        overlap=16,
+        search_area_size=32,
+    )
+    assert isinstance(flow, jnp.ndarray)
+    assert flow.shape[-1] == 2

--- a/tests/unit/flow/test_openpiv_jax_jit.py
+++ b/tests/unit/flow/test_openpiv_jax_jit.py
@@ -23,6 +23,7 @@ from flowgym.flow.open_piv.process import (
     get_field_shape,
     get_rect_coordinates,
     normalize_intensity,
+    sig2noise_ratio,
     sliding_window_array,
     subpixel_displacement,
     upsample_flow,
@@ -212,3 +213,49 @@ def test_extended_search_area_piv_jit_no_recompile(image_pair):
         img1b, img2b, window_size=32, search_area_size=32, overlap=16
     )
     _assert_same(ref, out)
+
+
+@pytest.mark.parametrize("sig2noise_method", ["peak2peak", "peak2mean"])
+def test_sig2noise_ratio_jit(windows, sig2noise_method):
+    """sig2noise_ratio traces under jit and matches its eager output."""
+    corr = fft_correlate_images(windows, windows)
+    jitted = jax.jit(
+        sig2noise_ratio, static_argnames=("sig2noise_method", "width")
+    )
+    _assert_same(
+        sig2noise_ratio(corr, sig2noise_method=sig2noise_method, width=2),
+        jitted(corr, sig2noise_method=sig2noise_method, width=2),
+    )
+
+
+def test_extended_search_area_piv_sig2noise_jit(image_pair):
+    """The pipeline with sig2noise traces with static method and geometry."""
+    img1, img2 = image_pair
+    jitted = jax.jit(
+        extended_search_area_piv,
+        static_argnames=(
+            "window_size",
+            "search_area_size",
+            "overlap",
+            "sig2noise_method",
+            "width",
+        ),
+    )
+    flow_e, s2n_e = extended_search_area_piv(
+        img1,
+        img2,
+        window_size=32,
+        search_area_size=32,
+        overlap=16,
+        sig2noise_method="peak2peak",
+    )
+    flow_c, s2n_c = jitted(
+        img1,
+        img2,
+        window_size=32,
+        search_area_size=32,
+        overlap=16,
+        sig2noise_method="peak2peak",
+    )
+    _assert_same(flow_e, flow_c)
+    _assert_same(s2n_e, s2n_c)

--- a/tests/unit/flow/test_openpiv_jax_numerical.py
+++ b/tests/unit/flow/test_openpiv_jax_numerical.py
@@ -8,11 +8,25 @@ implementation it mirrors, so the two stay numerically aligned:
 - ``extended_search_area_piv`` (full pipeline) vs
   ``pyprocess.extended_search_area_piv``
 - ``replace_outliers`` vs ``openpiv.filters.replace_outliers``
+- ``find_all_second_peaks`` vs ``pyprocess.find_all_second_peaks``
+- ``sig2noise_ratio`` vs ``pyprocess.vectorized_sig2noise_ratio``
 
 The per-component tests (FFT correlation, peak finding, normalization,
 sliding windows, coordinate grids) live in ``test_openpiv_jax``; this
-module covers the sub-pixel stage, the end-to-end displacement field, and
-outlier replacement.
+module covers the sub-pixel stage, the end-to-end displacement field,
+outlier replacement, and the signal-to-noise ratio.
+
+Sig2noise parity note: the JAX :func:`sig2noise_ratio` mirrors
+``vectorized_sig2noise_ratio`` with one deliberate divergence. The
+reference computes a validity ``flag`` per window (weak or border first
+peak, and for ``peak2peak`` a weak or border second peak) but never
+applies it — ``peak2peak[flag is True] = 0`` indexes with the Python
+expression ``flag is True`` (always ``False``), which numpy treats as an
+empty boolean mask, so the assignment is a no-op in openpiv 0.25.4. The
+JAX port applies the flag as evidently intended (the loop-based
+``pyprocess.sig2noise_ratio`` does zero out failed windows). Parity is
+therefore pinned in two parts: unflagged windows must match the
+vectorized reference exactly, flagged windows must be zero.
 """
 
 import jax.numpy as jnp
@@ -25,7 +39,9 @@ from flowgym.flow.open_piv.process import (
     extended_search_area_piv,
     fft_correlate_images,
     find_all_first_peaks,
+    find_all_second_peaks,
     get_field_shape,
+    sig2noise_ratio,
     sliding_window_array,
     subpixel_displacement,
 )
@@ -336,3 +352,272 @@ def test_replace_outliers_vmap_over_batch():
     # Valid positions in the other samples are unchanged too.
     valid = ~flags
     np.testing.assert_allclose(out[valid], field[valid], atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# find_all_second_peaks / sig2noise_ratio helpers
+# ---------------------------------------------------------------------------
+def _pipeline_correlation(window_size=32, overlap=16, seed=0):
+    """Correlation maps as produced by the JAX PIV pipeline, flattened.
+
+    Returns a ``(n_windows, window_size, window_size)`` float32 array so the
+    same maps can be fed verbatim to both implementations.
+    """
+    frame_a, frame_b = _shifted_pair(96, 96, shift_y=2, shift_x=-3, seed=seed)
+    aa = sliding_window_array(
+        jnp.asarray(frame_a)[None],
+        (window_size, window_size),
+        (overlap, overlap),
+    )
+    bb = sliding_window_array(
+        jnp.asarray(frame_b)[None],
+        (window_size, window_size),
+        (overlap, overlap),
+    )
+    return fft_correlate_images(aa, bb)[0]
+
+
+def _reference_flags(corr, sig2noise_method, width):
+    """Recompute the validity flag the reference intends (but never applies).
+
+    This mirrors the flag construction inside
+    ``pyprocess.vectorized_sig2noise_ratio`` using the reference's own peak
+    finders, so the parity tests can compare flag-free windows exactly and
+    assert zeroing on the flagged ones.
+    """
+    ind1, peaks1 = pyprocess.find_all_first_peaks(corr)
+    p1i, p1j = ind1[:, 1], ind1[:, 2]
+    flag = (
+        (peaks1 < 1e-3)
+        | (p1i == 0)
+        | (p1i == corr.shape[1] - 1)
+        | (p1j == 0)
+        | (p1j == corr.shape[2] - 1)
+    )
+    if sig2noise_method == "peak2peak":
+        ind2, peaks2 = pyprocess.find_all_second_peaks(corr, width=width)
+        p2i, p2j = ind2[:, 1], ind2[:, 2]
+        flag = (
+            flag
+            | (peaks2 < 1e-3)
+            | (p2i == 0)
+            | (p2i == corr.shape[1] - 1)
+            | (p2j == 0)
+            | (p2j == corr.shape[2] - 1)
+        )
+    return np.asarray(flag, dtype=bool)
+
+
+# ---------------------------------------------------------------------------
+# find_all_second_peaks
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("width", [1, 2, 3])
+def test_find_all_second_peaks_matches_reference(width):
+    """Second-peak indices and heights match the reference exactly."""
+    corr = np.asarray(_pipeline_correlation(seed=1))
+
+    ind_ref, peaks_ref = pyprocess.find_all_second_peaks(corr, width=width)
+    p2i, p2j, peaks2 = find_all_second_peaks(jnp.asarray(corr), width=width)
+
+    np.testing.assert_array_equal(np.asarray(p2i), ind_ref[:, 1])
+    np.testing.assert_array_equal(np.asarray(p2j), ind_ref[:, 2])
+    np.testing.assert_allclose(
+        np.asarray(peaks2), np.asarray(peaks_ref), rtol=1e-6
+    )
+
+
+@pytest.mark.parametrize("width", [1, 2])
+def test_find_all_second_peaks_random_maps(width):
+    """Reference parity also holds on unstructured random maps."""
+    rng = np.random.RandomState(7)
+    corr = rng.rand(40, 24, 24).astype(np.float32)
+
+    ind_ref, peaks_ref = pyprocess.find_all_second_peaks(corr, width=width)
+    p2i, p2j, peaks2 = find_all_second_peaks(jnp.asarray(corr), width=width)
+
+    np.testing.assert_array_equal(np.asarray(p2i), ind_ref[:, 1])
+    np.testing.assert_array_equal(np.asarray(p2j), ind_ref[:, 2])
+    np.testing.assert_allclose(
+        np.asarray(peaks2), np.asarray(peaks_ref), rtol=1e-6
+    )
+
+
+def test_find_all_second_peaks_border_peak_box_is_clipped():
+    """A first peak at the map border clips the exclusion box, as in openpiv."""
+    corr = np.full((1, 16, 16), 0.1, dtype=np.float32)
+    corr[0, 0, 0] = 1.0  # first peak in the corner
+    corr[0, 8, 8] = 0.5  # second peak well outside the box
+
+    ind_ref, peaks_ref = pyprocess.find_all_second_peaks(corr, width=2)
+    p2i, p2j, peaks2 = find_all_second_peaks(jnp.asarray(corr), width=2)
+
+    np.testing.assert_array_equal(np.asarray(p2i), ind_ref[:, 1])
+    np.testing.assert_array_equal(np.asarray(p2j), ind_ref[:, 2])
+    np.testing.assert_allclose(np.asarray(peaks2), np.asarray(peaks_ref))
+
+
+# ---------------------------------------------------------------------------
+# sig2noise_ratio
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sig2noise_method", ["peak2peak", "peak2mean"])
+@pytest.mark.parametrize("width", [1, 2, 3])
+@pytest.mark.parametrize("window_size, overlap", [(32, 16), (16, 8), (64, 32)])
+def test_sig2noise_matches_reference_on_same_corr(
+    sig2noise_method, width, window_size, overlap
+):
+    """JAX s2n equals the vectorized reference on identical correlation maps.
+
+    Both implementations consume the exact same maps, so unflagged windows
+    must agree to float32 round-off; flagged windows must be zero on the JAX
+    side (the reference leaves them untouched due to its no-op flag bug).
+    """
+    corr = np.asarray(
+        _pipeline_correlation(window_size=window_size, overlap=overlap)
+    )
+
+    s2n_ref = pyprocess.vectorized_sig2noise_ratio(
+        corr, sig2noise_method=sig2noise_method, width=width
+    )
+    s2n_jax = np.asarray(
+        sig2noise_ratio(
+            jnp.asarray(corr), sig2noise_method=sig2noise_method, width=width
+        )
+    )
+    flags = _reference_flags(corr, sig2noise_method, width)
+
+    assert s2n_jax.shape == np.asarray(s2n_ref).shape
+    # The test must keep teeth: most windows are healthy on this data.
+    assert (~flags).mean() > 0.5
+    np.testing.assert_allclose(
+        s2n_jax[~flags], np.asarray(s2n_ref)[~flags], rtol=1e-5
+    )
+    np.testing.assert_array_equal(s2n_jax[flags], 0.0)
+
+
+def test_sig2noise_weak_first_peak_is_zeroed():
+    """A near-flat map (peak < 1e-3) yields zero, as both references intend."""
+    corr = np.full((3, 16, 16), 1e-5, dtype=np.float32)
+    corr[:, 8, 8] = 5e-4  # below the 1e-3 signal threshold
+
+    for method in ("peak2peak", "peak2mean"):
+        s2n = np.asarray(
+            sig2noise_ratio(jnp.asarray(corr), sig2noise_method=method)
+        )
+        np.testing.assert_array_equal(s2n, 0.0)
+        # The loop-based reference applies the same rule.
+        s2n_loop = pyprocess.sig2noise_ratio(
+            corr.astype(np.float64), sig2noise_method=method
+        )
+        np.testing.assert_array_equal(np.asarray(s2n_loop), 0.0)
+
+
+def test_sig2noise_border_first_peak_is_zeroed():
+    """A first peak on the map border is flagged and zeroed."""
+    corr = np.full((1, 16, 16), 0.1, dtype=np.float32)
+    corr[0, 0, 5] = 1.0
+
+    for method in ("peak2peak", "peak2mean"):
+        s2n = np.asarray(
+            sig2noise_ratio(jnp.asarray(corr), sig2noise_method=method)
+        )
+        np.testing.assert_array_equal(s2n, 0.0)
+        s2n_loop = pyprocess.sig2noise_ratio(
+            corr.astype(np.float64), sig2noise_method=method
+        )
+        np.testing.assert_array_equal(np.asarray(s2n_loop), 0.0)
+
+
+def test_sig2noise_border_second_peak_is_zeroed():
+    """peak2peak flags a second peak on the border (intended reference rule).
+
+    The vectorized reference builds exactly this flag and then drops it on
+    the floor (``flag is True`` no-op); the JAX port applies it.
+    """
+    corr = np.full((1, 16, 16), 0.1, dtype=np.float32)
+    corr[0, 8, 8] = 1.0  # healthy first peak
+    corr[0, 0, 3] = 0.9  # second peak on the border
+
+    s2n = np.asarray(
+        sig2noise_ratio(jnp.asarray(corr), sig2noise_method="peak2peak")
+    )
+    np.testing.assert_array_equal(s2n, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# extended_search_area_piv with sig2noise
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sig2noise_method", ["peak2peak", "peak2mean"])
+@pytest.mark.parametrize(
+    "window_size, search_area_size, overlap",
+    [(32, 32, 16), (16, 32, 8)],
+)
+def test_pipeline_sig2noise_matches_reference(
+    sig2noise_method, window_size, search_area_size, overlap
+):
+    """End-to-end s2n matches the openpiv pipeline on unflagged windows."""
+    height = width = 96
+    frame_a, frame_b = _shifted_pair(
+        height, width, shift_y=2, shift_x=3, seed=5
+    )
+
+    _u_ref, _v_ref, s2n_ref = pyprocess.extended_search_area_piv(
+        frame_a.copy(),
+        frame_b.copy(),
+        window_size=window_size,
+        overlap=overlap,
+        search_area_size=search_area_size,
+        correlation_method="circular",
+        subpixel_method="gaussian",
+        sig2noise_method=sig2noise_method,
+        normalized_correlation=True,
+        use_vectorized=True,
+    )
+
+    flow, s2n = extended_search_area_piv(
+        jnp.asarray(frame_a)[None],
+        jnp.asarray(frame_b)[None],
+        window_size=window_size,
+        overlap=overlap,
+        search_area_size=search_area_size,
+        sig2noise_method=sig2noise_method,
+    )
+    s2n = np.asarray(s2n)[0]
+
+    n_rows, n_cols = get_field_shape(
+        (height, width),
+        (search_area_size, search_area_size),
+        (overlap, overlap),
+    )
+    assert flow.shape == (1, n_rows, n_cols, 2)
+    assert s2n.shape == (n_rows, n_cols)
+    assert np.asarray(s2n_ref).shape == (n_rows, n_cols)
+
+    # Recompute the reference's intended flags on its own correlation maps to
+    # exclude windows the reference fails to zero (no-op flag bug).
+    aa = pyprocess.sliding_window_array(
+        frame_a.astype(np.float32),
+        (search_area_size, search_area_size),
+        (overlap, overlap),
+    )
+    bb = pyprocess.sliding_window_array(
+        frame_b.astype(np.float32),
+        (search_area_size, search_area_size),
+        (overlap, overlap),
+    )
+    if search_area_size > window_size:
+        aa = pyprocess.normalize_intensity(aa)
+        bb = pyprocess.normalize_intensity(bb)
+        mask = np.zeros((search_area_size, search_area_size), dtype=aa.dtype)
+        pad = (search_area_size - window_size) // 2
+        mask[pad : search_area_size - pad, pad : search_area_size - pad] = 1
+        aa = aa * np.broadcast_to(mask, aa.shape)
+    corr_ref = pyprocess.fft_correlate_images(aa, bb)
+    flags = _reference_flags(corr_ref, sig2noise_method, width=2).reshape(
+        n_rows, n_cols
+    )
+
+    assert (~flags).mean() > 0.5
+    np.testing.assert_allclose(
+        s2n[~flags], np.asarray(s2n_ref)[~flags], rtol=1e-3
+    )
+    np.testing.assert_array_equal(s2n[flags], 0.0)


### PR DESCRIPTION
Stacked on #53.

## What

Ports the signal-to-noise ratio — the third output of the reference `pyprocess.extended_search_area_piv` that the JAX pipeline previously dropped — following the same parity-test methodology as #53:

- `find_all_second_peaks`: `(2·width+1)²` exclusion box around the first peak via an `|idx − peak| ≤ width` mask + `-inf` argmax (equivalent to the reference's clamped slices), vectorized over arbitrary leading dims.
- `sig2noise_ratio`: `peak2peak` and `peak2mean`, with the reference's weak-peak (`< 1e-3`) and border-peak validity rules.
- `extended_search_area_piv(..., sig2noise_method=, width=)`: optional, `@overload`-typed — existing callers keep the plain-array API; when set, returns `(flow, s2n)` with `s2n` of shape `(B, n_rows, n_cols)`.

## One deliberate divergence from the reference

openpiv 0.25.4's `vectorized_sig2noise_ratio` builds its validity flag and then drops it: `peak2peak[flag is True] = 0` indexes with the constant `False`, which numpy treats as an empty boolean mask — a no-op. This port applies the flag as intended (matching the loop-based `pyprocess.sig2noise_ratio` semantics on the shared rules). The divergence is documented in the docstring and the test module, and parity is pinned accordingly: **exact on unflagged windows, zero on flagged ones**.

## Tests (in the #53 file structure)

- `test_openpiv_jax_numerical.py`: second-peak parity index-for-index (widths 1–3, pipeline + random + border-clipped maps); same-corr s2n parity across 2 methods × 3 widths × 3 window configs with reference-flag-aware comparison; crafted flag cases cross-checked against the loop-based reference; end-to-end pipeline s2n vs `pyprocess.extended_search_area_piv` (standard + extended search).
- `test_openpiv_jax_jit.py`: jit ≡ eager for `sig2noise_ratio` and the full pipeline with s2n (static method/geometry args).
- `test_openpiv_jax.py`: leading-dim vectorization, flow-only backward-compat return, invalid-method `ValueError`.

90/90 openpiv tests pass locally (CPU); ruff (pinned 0.14.1), pydoclint and basedpyright clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)