### PR TITLE
feat(open_piv): port sig2noise_val outlier mask

### DIFF
--- a/src/flowgym/flow/open_piv/process.py
+++ b/src/flowgym/flow/open_piv/process.py
@@ -372,12 +372,21 @@ def sig2noise_val(s2n: jnp.ndarray, threshold: float = 1.0) -> jnp.ndarray:
     NaN entries in ``s2n`` yield ``False`` (not flagged), since ``nan <
     threshold`` is ``False``, matching the reference.
 
+    Note:
+        This returns openpiv's convention, where ``True`` marks an *outlier*.
+        That is the **inverse** of flowgym's ``postprocess`` mask convention
+        (``True``/``1`` means *valid*; see ``postprocess.data_validation``).
+        Invert the result (``~mask``) before composing it with ``postprocess``
+        masks, otherwise it rejects exactly the vectors it should keep. The
+        openpiv name is kept for port parity.
+
     Args:
         s2n: Signal-to-noise ratios of any shape.
         threshold: Vectors with ``s2n < threshold`` are flagged.
 
     Returns:
-        Boolean array of the same shape as ``s2n``; ``True`` marks outliers.
+        Boolean array of the same shape as ``s2n``; ``True`` marks outliers
+        (openpiv convention -- see the Note above).
     """
     return s2n < threshold
 

--- a/src/flowgym/flow/open_piv/process.py
+++ b/src/flowgym/flow/open_piv/process.py
@@ -361,6 +361,27 @@ def sig2noise_ratio(
     return jnp.where(flag, 0.0, ratio)
 
 
+def sig2noise_val(s2n: jnp.ndarray, threshold: float = 1.0) -> jnp.ndarray:
+    """Flag vectors whose signal-to-noise ratio is below a threshold.
+
+    JAX port of ``openpiv.validation.sig2noise_val``: vectors whose
+    signal-to-noise ratio (e.g. from :func:`sig2noise_ratio`) is below
+    ``threshold`` are marked as outliers. This completes the standard
+    signal-to-noise outlier-rejection path.
+
+    NaN entries in ``s2n`` yield ``False`` (not flagged), since ``nan <
+    threshold`` is ``False``, matching the reference.
+
+    Args:
+        s2n: Signal-to-noise ratios of any shape.
+        threshold: Vectors with ``s2n < threshold`` are flagged.
+
+    Returns:
+        Boolean array of the same shape as ``s2n``; ``True`` marks outliers.
+    """
+    return s2n < threshold
+
+
 def subpixel_displacement(
     corr: jnp.ndarray,
     peaks_i: jnp.ndarray,

--- a/tests/unit/flow/test_openpiv_jax_jit.py
+++ b/tests/unit/flow/test_openpiv_jax_jit.py
@@ -24,6 +24,7 @@ from flowgym.flow.open_piv.process import (
     get_rect_coordinates,
     normalize_intensity,
     sig2noise_ratio,
+    sig2noise_val,
     sliding_window_array,
     subpixel_displacement,
     upsample_flow,
@@ -225,6 +226,16 @@ def test_sig2noise_ratio_jit(windows, sig2noise_method):
     _assert_same(
         sig2noise_ratio(corr, sig2noise_method=sig2noise_method, width=2),
         jitted(corr, sig2noise_method=sig2noise_method, width=2),
+    )
+
+
+def test_sig2noise_val_jit(windows):
+    """sig2noise_val traces under jit and matches its eager output."""
+    s2n = sig2noise_ratio(fft_correlate_images(windows, windows))
+    jitted = jax.jit(sig2noise_val, static_argnames="threshold")
+    np.testing.assert_array_equal(
+        np.asarray(sig2noise_val(s2n, threshold=1.0)),
+        np.asarray(jitted(s2n, threshold=1.0)),
     )
 
 

--- a/tests/unit/flow/test_openpiv_jax_numerical.py
+++ b/tests/unit/flow/test_openpiv_jax_numerical.py
@@ -32,7 +32,7 @@ vectorized reference exactly, flagged windows must be zero.
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from openpiv import filters, pyprocess
+from openpiv import filters, pyprocess, validation
 
 from flowgym.flow.open_piv.openpiv_jax import replace_outliers
 from flowgym.flow.open_piv.process import (
@@ -42,6 +42,7 @@ from flowgym.flow.open_piv.process import (
     find_all_second_peaks,
     get_field_shape,
     sig2noise_ratio,
+    sig2noise_val,
     sliding_window_array,
     subpixel_displacement,
 )
@@ -621,3 +622,54 @@ def test_pipeline_sig2noise_matches_reference(
         s2n[~flags], np.asarray(s2n_ref)[~flags], rtol=1e-3
     )
     np.testing.assert_array_equal(s2n[flags], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# sig2noise_val
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("threshold", [0.8, 1.0, 1.5, 2.0])
+@pytest.mark.parametrize("shape", [(7, 9), (3, 5, 5)])
+def test_sig2noise_val_matches_reference(threshold, shape):
+    """sig2noise_val matches openpiv.validation.sig2noise_val (2D and 3D)."""
+    rng = np.random.RandomState(sum(shape))
+    s2n = (rng.rand(*shape) * 3.0).astype(np.float64)
+
+    ref = validation.sig2noise_val(s2n.copy(), threshold=threshold)
+    got = np.asarray(sig2noise_val(jnp.asarray(s2n), threshold=threshold))
+
+    assert got.dtype == bool
+    np.testing.assert_array_equal(got, np.asarray(ref))
+
+
+def test_sig2noise_val_nan_is_not_flagged():
+    """NaN ratios are not flagged, matching numpy's nan < threshold == False."""
+    s2n = np.array([[1.5, np.nan], [0.5, 2.0]], dtype=np.float64)
+    ref = validation.sig2noise_val(s2n.copy(), threshold=1.0)
+    got = np.asarray(sig2noise_val(jnp.asarray(s2n), threshold=1.0))
+    np.testing.assert_array_equal(got, np.asarray(ref))
+    assert not bool(got[0, 1])  # the NaN entry stays valid
+
+
+def test_sig2noise_val_on_pipeline_ratios_matches_reference():
+    """On real pipeline s2n values, the mask matches openpiv's masking step.
+
+    This isolates the thresholding step: the JAX pipeline's signal-to-noise
+    array is fed to both implementations, so the comparison does not depend
+    on the (documented) sig2noise_ratio flag divergence between the JAX and
+    openpiv ratio computations.
+    """
+    frame_a, frame_b = _shifted_pair(96, 96, shift_y=2, shift_x=-3, seed=11)
+    _, s2n = extended_search_area_piv(
+        jnp.asarray(frame_a)[None],
+        jnp.asarray(frame_b)[None],
+        window_size=32,
+        overlap=16,
+        search_area_size=32,
+        sig2noise_method="peak2peak",
+    )
+    s2n_np = np.asarray(s2n[0])
+
+    for threshold in (0.5, 1.0, 1.3):
+        mask_jax = np.asarray(sig2noise_val(s2n[0], threshold=threshold))
+        mask_ref = validation.sig2noise_val(s2n_np.copy(), threshold=threshold)
+        np.testing.assert_array_equal(mask_jax, np.asarray(mask_ref))

--- a/tests/unit/flow/test_openpiv_jax_numerical.py
+++ b/tests/unit/flow/test_openpiv_jax_numerical.py
@@ -29,6 +29,7 @@ therefore pinned in two parts: unflagged windows must match the
 vectorized reference exactly, flagged windows must be zero.
 """
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -636,9 +637,18 @@ def test_sig2noise_val_matches_reference(threshold, shape):
 
     ref = validation.sig2noise_val(s2n.copy(), threshold=threshold)
     got = np.asarray(sig2noise_val(jnp.asarray(s2n), threshold=threshold))
+    jit_got = np.asarray(
+        jax.jit(sig2noise_val, static_argnames="threshold")(
+            jnp.asarray(s2n), threshold=threshold
+        )
+    )
 
     assert got.dtype == bool
     np.testing.assert_array_equal(got, np.asarray(ref))
+    # Close the loop under jit too: a jitted-vs-eager-self check would agree
+    # even if both drifted from openpiv (e.g. dtype/weak-typing quirks), so
+    # pin the jitted path directly against the reference.
+    np.testing.assert_array_equal(jit_got, np.asarray(ref))
 
 
 def test_sig2noise_val_nan_is_not_flagged():


### PR DESCRIPTION
Branches off `dev`, independent of the other open PRs.

## What

Adds `sig2noise_val`, the JAX port of openpiv's `validation.sig2noise_val`: flag vectors whose signal-to-noise ratio is below a threshold. This **completes the signal-to-noise outlier-rejection path** — `sig2noise_ratio` (ported in #55) computes the ratio, and `sig2noise_val` turns it into a boolean outlier mask. Previously flowgym computed the ratio in JAX but had no JAX step to threshold it (only an external openpiv call).

It's a one-liner — `s2n < threshold`, `True` = outlier — and NaN ratios stay unflagged (`nan < threshold` is `False`), matching the reference exactly.

## Tests (1-to-1 openpiv parity, in the established files)

- `test_openpiv_jax_numerical.py`: parity vs `validation.sig2noise_val` on 2D and 3D arrays across thresholds; NaN-not-flagged parity; and on **real pipeline ratios** — this last one feeds the JAX pipeline's s2n to *both* implementations, isolating the threshold step from the documented `sig2noise_ratio` flag divergence (see #55).
- `test_openpiv_jax_jit.py`: jit-equivalence.

101 openpiv tests pass locally (CPU). ruff (pinned 0.14.1), pydoclint, basedpyright clean.

## Note

This returns openpiv's convention (`True` = outlier), matching the reference for parity. Wiring it into flowgym's postprocess validation framework (which uses `True` = valid and `(flow, mask, state)` tuples) would be a thin follow-up wrapper if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)