### PR TITLE
feat(scripts): generic, algorithm-agnostic cache collector + ensemble selector

### DIFF
--- a/docs/examples/caching.md
+++ b/docs/examples/caching.md
@@ -102,6 +102,71 @@ These scripts are meant to be practical references for the real example
 files, so the most important thing to compare is the difference between the
 first and second run.
 
+## Collecting caches from the command line
+
+The example scripts above generate their own data and configs. To fill a
+cache for your own estimator and dataset, you do not need a bespoke script:
+the standard evaluation entry point writes the cache for any estimator that
+implements `enrich()` (DIS, RAFT, openpiv, art_of_piv, …).
+
+Put the cache `spec` in the dataset config (this is the only
+estimator-specific part — it must match what the estimator's `enrich()`
+returns):
+
+```yaml
+caching:
+  spec:
+    epe: [float32, []]
+    relative_epe: [float32, []]
+  warm_start: index
+```
+
+Then point `--cache-root` (and optionally `--cache-id`) at the output. These
+flags supply the cache location, so the same dataset config can fill many
+caches without edits:
+
+```bash
+uv run python src/main.py --mode eval \
+    --estimator estimator.yaml --dataset dataset.yaml \
+    --cache-root caches/
+```
+
+The cache lands in `caches/<cache_id>/`, where `<cache_id>` is the base id
+plus the estimator's own config/weights suffix (from `get_cache_id_suffix`).
+
+## Sweeping many configs
+
+`scripts/collect_cache.py` runs the command above once per estimator config,
+into a shared `--cache-root`. Each config gets its own `<cache_id>` subdir,
+runs as an isolated subprocess (so JIT/GPU memory is released between
+configs), and the sweep continues past a failing config:
+
+```bash
+uv run python scripts/collect_cache.py \
+    --models estimators/*.yaml \
+    --dataset dataset.yaml \
+    --cache-root caches/
+```
+
+Nothing in either step is specific to an algorithm — the dataset config's
+`spec` is the only knob that depends on the estimator.
+
+## Selecting an ensemble from a cache
+
+`scripts/select_ensemble.py` consumes a directory of such caches and picks a
+size-`K` subset minimizing the aggregate per-image best error (greedy, plus
+an exact MILP for the mean aggregator with `--exact`):
+
+```bash
+uv run python scripts/select_ensemble.py \
+    --cache-root caches/ --K 3 --metric epe
+```
+
+`--metric` selects the parquet error column (default `epe`). Timing is
+optional: pass `--time-limit` only if each cache dir carries a `timing.json`
+(timing is device-dependent and collected separately from the
+device-independent error).
+
 ## Related docs
 
 - [Flow evaluation](flow-eval.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "ipywidgets",
     "robo-goggles>=0.2.0",
     "pip>=26.1",
+    "scipy>=1.11.0",
 ]
 
 [project.urls]

--- a/scripts/collect_cache.py
+++ b/scripts/collect_cache.py
@@ -65,7 +65,9 @@ def materialize_model_configs(
 
     Each entry is emitted as a ``{estimator, estimate_type, config}`` YAML
     (the ``name`` key, which is list-only metadata, is dropped) so it can be
-    passed to ``src/main.py --model``.
+    passed to ``src/main.py --model``. The entry ``idx`` prefixes every
+    filename so two entries that share a ``name`` (or sanitize to the same
+    stem) never overwrite each other.
 
     Args:
         entries: Estimator-entry dicts from :func:`load_estimators_list`.
@@ -79,7 +81,7 @@ def materialize_model_configs(
         model = {k: v for k, v in entry.items() if k != "name"}
         raw_stem = str(entry.get("name", f"model_{idx}"))
         stem = "".join(c if c.isalnum() or c in "-_" else "_" for c in raw_stem)
-        out = workdir / f"{stem}.yaml"
+        out = workdir / f"{idx:03d}_{stem}.yaml"
         out.write_text(yaml.dump(model), encoding="utf-8")
         paths.append(out)
     return paths

--- a/scripts/collect_cache.py
+++ b/scripts/collect_cache.py
@@ -25,9 +25,64 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
+import yaml
+
 DEFAULT_RUNNER = "uv run python"
+
+
+def load_estimators_list(path: Path) -> list[dict]:
+    """Load the ``estimators:`` entries from an estimators_list YAML.
+
+    This is the multi-estimator format consumed by ``art_of_piv`` (e.g.
+    ``dis_models_20.yaml``): a top-level ``estimators:`` key holding a list
+    of ``{name, estimator, estimate_type, config}`` dicts.
+
+    Args:
+        path: Path to the estimators_list YAML.
+
+    Returns:
+        The list of estimator-entry dicts.
+
+    Raises:
+        ValueError: If the file has no non-empty ``estimators:`` list.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    estimators = data.get("estimators") if isinstance(data, dict) else None
+    if not estimators:
+        raise ValueError(f"{path} has no non-empty `estimators:` list")
+    return estimators
+
+
+def materialize_model_configs(
+    entries: list[dict],
+    workdir: Path,
+) -> list[Path]:
+    """Write estimators_list entries as standalone model config YAMLs.
+
+    Each entry is emitted as a ``{estimator, estimate_type, config}`` YAML
+    (the ``name`` key, which is list-only metadata, is dropped) so it can be
+    passed to ``src/main.py --model``.
+
+    Args:
+        entries: Estimator-entry dicts from :func:`load_estimators_list`.
+        workdir: Directory to write the per-entry YAMLs into.
+
+    Returns:
+        Paths to the written model config YAMLs, in entry order.
+    """
+    paths: list[Path] = []
+    for idx, entry in enumerate(entries):
+        model = {k: v for k, v in entry.items() if k != "name"}
+        raw_stem = str(entry.get("name", f"model_{idx}"))
+        stem = "".join(c if c.isalnum() or c in "-_" else "_" for c in raw_stem)
+        out = workdir / f"{stem}.yaml"
+        out.write_text(yaml.dump(model), encoding="utf-8")
+        paths.append(out)
+    return paths
 
 
 def build_eval_command(
@@ -82,8 +137,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--models",
         type=Path,
         nargs="+",
-        required=True,
-        help="Model config YAMLs to evaluate (one cache each).",
+        default=None,
+        help="Standalone model config YAMLs to evaluate (one cache each).",
+    )
+    parser.add_argument(
+        "--estimators-list",
+        type=Path,
+        nargs="+",
+        default=None,
+        help="estimators_list YAMLs (a top-level `estimators:` list, e.g. "
+        "dis_models_20.yaml). Every sub-estimator is collected as its own "
+        "cache; nested lists dedupe by cache_id, so the superset suffices.",
     )
     parser.add_argument(
         "--dataset",
@@ -122,7 +186,10 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Stop at the first failing config instead of continuing.",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if not args.models and not args.estimators_list:
+        parser.error("provide --models and/or --estimators-list")
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -135,7 +202,16 @@ def main(argv: list[str] | None = None) -> int:
         Process exit code (0 if every config succeeded, 1 otherwise).
     """
     args = _parse_args(argv)
-    models = args.models if args.limit is None else args.models[: args.limit]
+
+    models: list[Path] = list(args.models or [])
+    if args.estimators_list:
+        workdir = Path(tempfile.mkdtemp(prefix="collect_cache_"))
+        for list_path in args.estimators_list:
+            entries = load_estimators_list(list_path)
+            models.extend(materialize_model_configs(entries, workdir))
+
+    if args.limit is not None:
+        models = models[: args.limit]
     runner = tuple(args.runner.split())
 
     n_ok = 0

--- a/scripts/collect_cache.py
+++ b/scripts/collect_cache.py
@@ -1,0 +1,169 @@
+"""Fill per-image error caches for many model configs over one dataset.
+
+Estimator-agnostic sweep producer. For each candidate model config it runs
+``src/main.py --mode eval`` with a shared ``--cache-root``; the dataset
+config supplies the caching ``spec`` (e.g. ``{epe: [float32, []]}``), and
+each estimator's ``get_cache_id_suffix`` keeps the per-config caches in
+separate ``<cache-root>/<cache_id>/`` directories. Nothing here is specific
+to any algorithm -- DIS, RAFT, openpiv, art_of_piv all flow through the same
+path.
+
+Runs are independent subprocesses (so JIT/GPU memory is released between
+configs) and the sweep continues past a failing config unless
+``--halt-on-error`` is set. A one-line summary is printed at the end.
+
+Example:
+
+    uv run python scripts/collect_cache.py \\
+        --models experiments/.../models/dis_models_*.yaml \\
+        --dataset tune.yaml \\
+        --cache-root caches/
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_RUNNER = "uv run python"
+
+
+def build_eval_command(
+    runner: tuple[str, ...],
+    model: Path,
+    dataset: Path,
+    cache_root: Path,
+    cache_id: str | None = None,
+) -> list[str]:
+    """Build the ``src/main.py --mode eval`` command for one model config.
+
+    Args:
+        runner: Interpreter prefix tokens (e.g. ``("uv", "run", "python")``).
+        model: Path to the model config YAML.
+        dataset: Path to the dataset config YAML (carries the caching spec).
+        cache_root: Shared cache root for the sweep.
+        cache_id: Optional base cache id forwarded to main.py.
+
+    Returns:
+        The argument list to hand to :func:`subprocess.run`.
+    """
+    cmd = [
+        *runner,
+        "src/main.py",
+        "--mode",
+        "eval",
+        "--estimator",
+        str(model),
+        "--dataset",
+        str(dataset),
+        "--cache-root",
+        str(cache_root),
+    ]
+    if cache_id is not None:
+        cmd += ["--cache-id", cache_id]
+    return cmd
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional explicit argument list (for testing).
+
+    Returns:
+        The parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Fill error caches for many model configs over a dataset.",
+    )
+    parser.add_argument(
+        "--models",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="Model config YAMLs to evaluate (one cache each).",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        required=True,
+        help="Dataset config YAML; must carry a caching block with a spec.",
+    )
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        required=True,
+        help="Shared output root for the per-config caches.",
+    )
+    parser.add_argument(
+        "--cache-id-base",
+        type=str,
+        default=None,
+        help="Base cache id shared by all configs (the per-config suffix is "
+        "still appended). Defaults to the dataset config's cache_id.",
+    )
+    parser.add_argument(
+        "--runner",
+        type=str,
+        default=DEFAULT_RUNNER,
+        help="Interpreter prefix for src/main.py "
+        f"(default: {DEFAULT_RUNNER!r}).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Only process the first N model configs.",
+    )
+    parser.add_argument(
+        "--halt-on-error",
+        action="store_true",
+        help="Stop at the first failing config instead of continuing.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sweep.
+
+    Args:
+        argv: Optional explicit argument list (for testing).
+
+    Returns:
+        Process exit code (0 if every config succeeded, 1 otherwise).
+    """
+    args = _parse_args(argv)
+    models = args.models if args.limit is None else args.models[: args.limit]
+    runner = tuple(args.runner.split())
+
+    n_ok = 0
+    n_fail = 0
+    for idx, model in enumerate(models, start=1):
+        cmd = build_eval_command(
+            runner,
+            model,
+            args.dataset,
+            args.cache_root,
+            args.cache_id_base,
+        )
+        print(
+            f"[{idx}/{len(models)}] {model} -> {args.cache_root}",
+            flush=True,
+        )
+        returncode = subprocess.run(cmd, check=False).returncode
+        if returncode == 0:
+            n_ok += 1
+        else:
+            n_fail += 1
+            print(f"  FAILED ({model}, exit {returncode})", file=sys.stderr)
+            if args.halt_on_error:
+                break
+
+    print(f"done: {n_ok} ok, {n_fail} failed, {len(models)} total")
+    return 1 if n_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/select_ensemble.py
+++ b/scripts/select_ensemble.py
@@ -27,16 +27,64 @@ Example:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pyarrow.parquet as pq
+import yaml
 from scipy.optimize import Bounds, LinearConstraint, milp
 from scipy.sparse import csr_matrix
+
+
+def _export_models(
+    summary: dict[str, Any],
+    path: Path,
+    estimator: str,
+    estimate_type: str,
+) -> tuple[int, int]:
+    """Write a selection's configs as a collect-ready estimators_list YAML.
+
+    The output is the ``estimators:`` format consumed by
+    ``collect_cache.py --estimators-list``, so a chosen subset can be
+    re-collected on other splits (train/val/test) directly. Candidates
+    whose cache stored no ``config`` (e.g. caches written with only a
+    ``meta.json``) are skipped.
+
+    Args:
+        summary: A selection summary from :func:`_summarize_selection`.
+        path: Output YAML path.
+        estimator: ``estimator`` field for each emitted entry.
+        estimate_type: ``estimate_type`` field for each emitted entry.
+
+    Returns:
+        A pair ``(written, skipped)`` counting emitted and config-less
+        entries.
+    """
+    entries: list[dict[str, Any]] = []
+    skipped = 0
+    for entry in summary["selected"]:
+        config = entry.get("config") or {}
+        if not config:
+            skipped += 1
+            continue
+        entries.append(
+            {
+                "name": entry["cache_id"],
+                "estimator": estimator,
+                "estimate_type": estimate_type,
+                "config": config,
+            }
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.dump({"estimators": entries}, fh, sort_keys=False)
+    return len(entries), skipped
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -106,6 +154,27 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         default=None,
         help="Optional path to dump the full result JSON.",
+    )
+    parser.add_argument(
+        "--export-models",
+        type=Path,
+        default=None,
+        help="Write the selected subset's configs as an estimators_list "
+        "YAML (consumable by collect_cache.py --estimators-list) to "
+        "re-collect on other splits.",
+    )
+    parser.add_argument(
+        "--export-estimator",
+        type=str,
+        default="dis_jax",
+        help="`estimator` field for --export-models entries (default: "
+        "dis_jax).",
+    )
+    parser.add_argument(
+        "--export-estimate-type",
+        type=str,
+        default="flow",
+        help="`estimate_type` field for --export-models entries.",
     )
     parser.add_argument(
         "-v",
@@ -187,8 +256,7 @@ def _load_cache(
         stat to filter on.
 
     Raises:
-        RuntimeError: If no candidates were found or key sets disagree
-            across candidates.
+        RuntimeError: If no candidates with data shards were found.
     """
     all_subdirs = sorted(p for p in cache_root.iterdir() if p.is_dir())
     subdirs = [p for p in all_subdirs if list((p / "data").glob("part-*"))]
@@ -207,35 +275,49 @@ def _load_cache(
     if not subdirs:
         raise RuntimeError(f"no candidates with data shards under {cache_root}")
 
-    canonical_keys: np.ndarray | None = None
-    err_rows: list[np.ndarray] = []
-    cache_ids: list[str] = []
-    records: list[dict[str, Any]] = []
-
+    # Load every candidate, then keep only those sharing the majority key
+    # set. A union of caches can contain partial / interrupted ones (fewer
+    # rows); rather than aborting the whole selection, those are dropped
+    # with a warning so the consistent majority is still usable.
+    loaded: list[tuple[Path, dict[str, Any], np.ndarray, np.ndarray]] = []
+    sigs: list[str] = []
     for idx, subdir in enumerate(subdirs):
         record, keys, errors = _load_candidate(subdir, metric)
         order = np.argsort(keys, kind="stable")
         sorted_keys = keys[order]
-        if canonical_keys is None:
-            canonical_keys = sorted_keys
-            err_rows.append(errors[order])
-        else:
-            if sorted_keys.shape != canonical_keys.shape or not np.array_equal(
-                sorted_keys, canonical_keys
-            ):
-                raise RuntimeError(
-                    f"key set mismatch: {subdir} differs from {subdirs[0]}",
-                )
-            err_rows.append(errors[order])
-
-        cache_ids.append(record.get("cache_id", subdir.name))
-        records.append(record)
+        loaded.append((subdir, record, sorted_keys, errors[order]))
+        sigs.append(hashlib.md5(sorted_keys.tobytes()).hexdigest())
         if verbose and (idx + 1) % 100 == 0:
             print(f"loaded {idx + 1}/{len(subdirs)} candidates", flush=True)
 
-    assert canonical_keys is not None
+    majority_sig = Counter(sigs).most_common(1)[0][0]
+    dropped = [
+        (sd, sk)
+        for (sd, _, sk, _), sig in zip(loaded, sigs, strict=True)
+        if sig != majority_sig
+    ]
+    kept = [
+        item
+        for item, sig in zip(loaded, sigs, strict=True)
+        if sig == majority_sig
+    ]
+    if dropped:
+        print(
+            f"warning: dropped {len(dropped)} candidate(s) whose key set "
+            f"differs from the majority ({len(kept)} share it); likely "
+            "incomplete caches:",
+            file=sys.stderr,
+        )
+        for sd, sk in dropped[:20]:
+            print(f"  - {sd.name} ({sk.size} keys)", file=sys.stderr)
+        if len(dropped) > 20:
+            print(f"  ... ({len(dropped) - 20} more)", file=sys.stderr)
 
-    E = np.stack(err_rows, axis=0).astype(np.float32, copy=False)
+    cache_ids = [rec.get("cache_id", sd.name) for (sd, rec, _, _) in kept]
+    records = [rec for (_, rec, _, _) in kept]
+    E = np.stack([er for (_, _, _, er) in kept], axis=0).astype(
+        np.float32, copy=False
+    )
     return E, cache_ids, records
 
 
@@ -684,6 +766,19 @@ def main(argv: list[str] | None = None) -> int:
         with args.out.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2)
         print(f"wrote {args.out}")
+
+    if args.export_models is not None:
+        best = exact_summary if exact_summary is not None else greedy_summary
+        written, skipped = _export_models(
+            best,
+            args.export_models,
+            args.export_estimator,
+            args.export_estimate_type,
+        )
+        msg = f"exported {written} model config(s) to {args.export_models}"
+        if skipped:
+            msg += f" ({skipped} skipped: no stored config)"
+        print(msg)
 
     return 0
 

--- a/scripts/select_ensemble.py
+++ b/scripts/select_ensemble.py
@@ -1,0 +1,692 @@
+"""Select a K-subset of candidates minimizing an aggregate per-image error.
+
+Algorithm-agnostic ensemble selection over a sweep cache: any cache whose
+per-candidate subdirs hold ``data/part-*.parquet`` rows with a ``key``
+column and a scalar error column (``--metric``, default ``epe``) works,
+regardless of which estimator produced it. Each subdir is one candidate.
+
+The script picks a subset ``S`` (|S| = K) that minimizes the aggregator
+(mean or median) over the per-image best error,
+
+    cost(S) = aggregator_i( min_{a in S} e_{a, i} ),
+
+optionally subject to a per-candidate inference-time bound. A greedy
+solver runs always; an exact MILP (HiGHS via :func:`scipy.optimize.milp`)
+is available for the mean aggregator with ``--exact``.
+
+Timing is optional: a candidate only needs a ``timing.json`` when a
+finite ``--time-limit`` is requested (timing is device-dependent and
+collected separately); error is device-independent and always present.
+
+Example:
+
+    uv run python scripts/select_ensemble.py \\
+        --cache-root dis_sweep_caches --K 3 --exact
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyarrow.parquet as pq
+from scipy.optimize import Bounds, LinearConstraint, milp
+from scipy.sparse import csr_matrix
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Optional explicit argument list (for testing).
+
+    Returns:
+        The parsed namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Select a K-subset of candidates minimizing per-image "
+        "error.",
+    )
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        required=True,
+        help="Root directory of the sweep cache (one subdir per candidate).",
+    )
+    parser.add_argument(
+        "--K",
+        type=int,
+        required=True,
+        help="Subset size.",
+    )
+    parser.add_argument(
+        "--metric",
+        type=str,
+        default="epe",
+        help="Parquet column holding the per-image scalar error to "
+        "minimize (default: epe).",
+    )
+    parser.add_argument(
+        "--time-limit",
+        type=float,
+        default=math.inf,
+        help="Per-candidate time bound (same units as --time-stat). When "
+        "finite, candidates without a timing.json are dropped.",
+    )
+    parser.add_argument(
+        "--aggregator",
+        choices=("mean", "median"),
+        default="mean",
+        help="How to aggregate the per-image best error across images.",
+    )
+    parser.add_argument(
+        "--time-stat",
+        choices=("mean_ms", "median_ms", "min_ms", "max_ms"),
+        default="mean_ms",
+        help="Which timing.json field to compare against --time-limit.",
+    )
+    parser.add_argument(
+        "--exact",
+        action="store_true",
+        help="Run exact MILP after greedy (only supported for mean).",
+    )
+    parser.add_argument(
+        "--milp-timeout",
+        type=float,
+        default=300.0,
+        help="HiGHS wall-time cap in seconds.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Optional path to dump the full result JSON.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Extra logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_candidate(
+    subdir: Path,
+    metric: str,
+) -> tuple[dict[str, Any], np.ndarray, np.ndarray]:
+    """Load a single candidate's metadata and per-image error rows.
+
+    Args:
+        subdir: Path to the candidate subdirectory.
+        metric: Parquet column holding the per-image scalar error.
+
+    Returns:
+        A triple ``(record, keys, errors)`` where ``record`` merges the
+        candidate's ``meta.json`` and (optional) ``timing.json`` payloads,
+        ``keys`` is a 1-D ``uint64`` array of image keys, and ``errors``
+        is a 1-D ``float32`` array in the same order as ``keys``.
+
+    Raises:
+        FileNotFoundError: If no data shards are present.
+    """
+    record: dict[str, Any] = {}
+    meta_path = subdir / "meta.json"
+    if meta_path.is_file():
+        with meta_path.open("r", encoding="utf-8") as fh:
+            record.update(json.load(fh))
+    timing_path = subdir / "timing.json"
+    if timing_path.is_file():
+        with timing_path.open("r", encoding="utf-8") as fh:
+            record.update(json.load(fh))
+
+    data_dir = subdir / "data"
+    shards = sorted(data_dir.glob("part-*.parquet"))
+    if not shards:
+        raise FileNotFoundError(f"no parquet shards under {data_dir}")
+
+    key_chunks: list[np.ndarray] = []
+    err_chunks: list[np.ndarray] = []
+    for shard in shards:
+        table = pq.read_table(shard, columns=["key", metric])
+        key_chunks.append(table.column("key").to_numpy())
+        err_chunks.append(
+            table.column(metric).to_numpy().astype(np.float32, copy=False),
+        )
+    keys = np.concatenate(key_chunks)
+    errors = np.concatenate(err_chunks).astype(np.float32, copy=False)
+    return record, keys, errors
+
+
+def _load_cache(
+    cache_root: Path,
+    metric: str,
+    verbose: bool,
+) -> tuple[np.ndarray, list[str], list[dict[str, Any]]]:
+    """Load the entire sweep cache into aligned arrays.
+
+    A subdirectory is a candidate iff it holds ``data/part-*.parquet``
+    shards; ``timing.json`` is optional (only needed for a finite time
+    bound) and ``meta.json`` supplies the cache id when present.
+
+    Args:
+        cache_root: Root directory of the sweep cache.
+        metric: Parquet column holding the per-image scalar error.
+        verbose: Whether to print per-candidate progress.
+
+    Returns:
+        A tuple ``(E, cache_ids, records)`` where ``E`` has shape
+        ``(N, M)`` of ``float32`` errors, ``cache_ids`` is the list of
+        cache ids in row order, and ``records`` holds the merged
+        meta/timing payload per candidate. The caller picks the timing
+        stat to filter on.
+
+    Raises:
+        RuntimeError: If no candidates were found or key sets disagree
+            across candidates.
+    """
+    all_subdirs = sorted(p for p in cache_root.iterdir() if p.is_dir())
+    subdirs = [p for p in all_subdirs if list((p / "data").glob("part-*"))]
+    skipped = [p for p in all_subdirs if p not in subdirs]
+    if skipped:
+        print(
+            f"warning: skipped {len(skipped)} subdir(s) under {cache_root} "
+            "without data shards (likely partial / interrupted runs)",
+            file=sys.stderr,
+        )
+        if verbose:
+            for p in skipped[:20]:
+                print(f"  - {p.name}", file=sys.stderr)
+            if len(skipped) > 20:
+                print(f"  ... ({len(skipped) - 20} more)", file=sys.stderr)
+    if not subdirs:
+        raise RuntimeError(f"no candidates with data shards under {cache_root}")
+
+    canonical_keys: np.ndarray | None = None
+    err_rows: list[np.ndarray] = []
+    cache_ids: list[str] = []
+    records: list[dict[str, Any]] = []
+
+    for idx, subdir in enumerate(subdirs):
+        record, keys, errors = _load_candidate(subdir, metric)
+        order = np.argsort(keys, kind="stable")
+        sorted_keys = keys[order]
+        if canonical_keys is None:
+            canonical_keys = sorted_keys
+            err_rows.append(errors[order])
+        else:
+            if sorted_keys.shape != canonical_keys.shape or not np.array_equal(
+                sorted_keys, canonical_keys
+            ):
+                raise RuntimeError(
+                    f"key set mismatch: {subdir} differs from {subdirs[0]}",
+                )
+            err_rows.append(errors[order])
+
+        cache_ids.append(record.get("cache_id", subdir.name))
+        records.append(record)
+        if verbose and (idx + 1) % 100 == 0:
+            print(f"loaded {idx + 1}/{len(subdirs)} candidates", flush=True)
+
+    assert canonical_keys is not None
+
+    E = np.stack(err_rows, axis=0).astype(np.float32, copy=False)
+    return E, cache_ids, records
+
+
+def _aggregate(values: np.ndarray, aggregator: str) -> float:
+    """Apply the configured aggregator to a 1-D EPE vector.
+
+    Args:
+        values: Per-image EPE values.
+        aggregator: ``"mean"`` or ``"median"``.
+
+    Returns:
+        The aggregated scalar cost.
+
+    Raises:
+        ValueError: If ``aggregator`` is not recognized.
+    """
+    if aggregator == "mean":
+        return float(np.mean(values))
+    if aggregator == "median":
+        return float(np.median(values))
+    raise ValueError(f"unknown aggregator {aggregator!r}")
+
+
+def _greedy_select(
+    E: np.ndarray,
+    K: int,
+    aggregator: str,
+    verbose: bool,
+) -> list[int]:
+    """Greedy subset selection minimizing the aggregated per-image best EPE.
+
+    Brute-force scan of all remaining candidates at every step. The
+    earlier draft used a Minoux-style lazy heap; that variant requires
+    a max-heap of marginal gains, not a min-heap of absolute costs, so
+    it was incorrect and has been removed. At the scales we care about
+    (N x M on the order of 10^6), the O(K * N * M) scan finishes in
+    well under a second and is obviously correct, regardless of the
+    aggregator's submodularity.
+
+    Args:
+        E: Algorithm x image EPE matrix of shape ``(N, M)``.
+        K: Desired subset size.
+        aggregator: ``"mean"`` or ``"median"``.
+        verbose: Whether to print per-step progress.
+
+    Returns:
+        A list of selected row indices in selection order.
+
+    Raises:
+        ValueError: If ``K`` exceeds ``N`` or is non-positive.
+        RuntimeError: If the greedy state becomes inconsistent (should
+            not happen in practice).
+    """
+    n_algos, n_images = E.shape
+    if K <= 0 or K > n_algos:
+        raise ValueError(
+            f"K={K} out of range for N={n_algos} surviving algorithms",
+        )
+
+    current_min = np.full(n_images, np.inf, dtype=np.float32)
+    selected: list[int] = []
+    remaining = set(range(n_algos))
+
+    while len(selected) < K:
+        best_a = -1
+        best_cost = math.inf
+        for a in sorted(remaining):
+            cand = np.minimum(current_min, E[a])
+            cost = _aggregate(cand, aggregator)
+            if cost < best_cost:
+                best_cost = cost
+                best_a = a
+        if best_a < 0:
+            raise RuntimeError("greedy scan failed to pick an element")
+        current_min = np.minimum(current_min, E[best_a])
+        selected.append(best_a)
+        remaining.discard(best_a)
+        if verbose:
+            print(
+                f"  step {len(selected)}: picked {best_a} cost={best_cost:.6f}",
+                flush=True,
+            )
+
+    return selected
+
+
+def _build_milp_constraints(
+    n_algos: int,
+    n_images: int,
+    K: int,
+) -> tuple[LinearConstraint, ...]:
+    """Build the LP/MILP constraints for the exact mean-aggregator solver.
+
+    Variables are laid out as ``[x_0, ..., x_{N-1}, y_{0,0}, y_{0,1},
+    ..., y_{N-1, M-1}]`` (algorithm indicators followed by per-pair
+    assignments, row-major over algorithms).
+
+    The three constraint blocks are:
+
+    * one equality fixing ``sum_a x_a == K``,
+    * ``M`` equalities ``sum_a y_{a,i} == 1`` (each image gets exactly
+      one assigned algorithm),
+    * ``N*M`` inequalities ``y_{a,i} - x_a <= 0`` linking assignment
+      to selection.
+
+    Args:
+        n_algos: Number of surviving algorithms ``N``.
+        n_images: Number of images ``M``.
+        K: Subset size.
+
+    Returns:
+        Three :class:`scipy.optimize.LinearConstraint` objects in the
+        order described above.
+    """
+    n_y = n_algos * n_images
+    n_vars = n_algos + n_y
+
+    # Block 1: sum x_a == K.
+    row1 = csr_matrix(
+        (
+            np.ones(n_algos, dtype=np.float64),
+            (np.zeros(n_algos, dtype=np.int64), np.arange(n_algos)),
+        ),
+        shape=(1, n_vars),
+    )
+    c1 = LinearConstraint(row1, lb=float(K), ub=float(K))
+
+    # Block 2: for each image i, sum_a y_{a,i} == 1.
+    rows: list[int] = []
+    cols: list[int] = []
+    for a in range(n_algos):
+        base = n_algos + a * n_images
+        rows.extend(range(n_images))
+        cols.extend(range(base, base + n_images))
+    data = np.ones(len(rows), dtype=np.float64)
+    img_mat = csr_matrix(
+        (data, (np.asarray(rows), np.asarray(cols))),
+        shape=(n_images, n_vars),
+    )
+    c2 = LinearConstraint(img_mat, lb=1.0, ub=1.0)
+
+    # Block 3: y_{a,i} - x_a <= 0 for every (a, i).
+    pair_rows = np.arange(n_y, dtype=np.int64)
+    pair_cols_y = n_algos + pair_rows
+    pair_cols_x = np.repeat(np.arange(n_algos, dtype=np.int64), n_images)
+    rows_all = np.concatenate([pair_rows, pair_rows])
+    cols_all = np.concatenate([pair_cols_y, pair_cols_x])
+    data_all = np.concatenate(
+        [np.ones(n_y, dtype=np.float64), -np.ones(n_y, dtype=np.float64)],
+    )
+    pair_mat = csr_matrix(
+        (data_all, (rows_all, cols_all)),
+        shape=(n_y, n_vars),
+    )
+    c3 = LinearConstraint(pair_mat, lb=-math.inf, ub=0.0)
+    return c1, c2, c3
+
+
+def _exact_milp(
+    E: np.ndarray,
+    K: int,
+    timeout_s: float,
+    verbose: bool,
+) -> tuple[list[int] | None, str, float | None]:
+    """Solve the exact mean-aggregator subset problem via HiGHS MILP.
+
+    Args:
+        E: Algorithm x image EPE matrix (``float32`` or ``float64``).
+        K: Subset size.
+        timeout_s: Wall-time cap passed to HiGHS.
+        verbose: Whether to print solver diagnostics.
+
+    Returns:
+        A tuple ``(selected, status_message, sum_objective)``. The
+        selection is ``None`` when HiGHS failed to return an integer
+        solution; the sum objective is the LP objective ``sum_{a,i}
+        e_{a,i} y_{a,i}`` (divide by ``M`` for mean EPE).
+    """
+    n_algos, n_images = E.shape
+    n_y = n_algos * n_images
+
+    c = np.concatenate(
+        [
+            np.zeros(n_algos, dtype=np.float64),
+            E.astype(np.float64, copy=False).reshape(-1),
+        ],
+    )
+
+    bounds = Bounds(lb=0.0, ub=1.0)
+    integrality = np.concatenate(
+        [
+            np.ones(n_algos, dtype=np.int64),
+            np.zeros(n_y, dtype=np.int64),
+        ],
+    )
+
+    constraints = _build_milp_constraints(n_algos, n_images, K)
+
+    result = milp(
+        c=c,
+        constraints=constraints,
+        bounds=bounds,
+        integrality=integrality,
+        options={"time_limit": float(timeout_s), "disp": bool(verbose)},
+    )
+
+    status_message = f"status={result.status} message={result.message!r}"
+    if result.x is None:
+        return None, status_message, None
+
+    x_part = np.asarray(result.x[:n_algos])
+    selected_arr = np.flatnonzero(x_part > 0.5)
+    if selected_arr.size != K:
+        return None, status_message, float(result.fun)
+    return selected_arr.tolist(), status_message, float(result.fun)
+
+
+def _summarize_selection(
+    selected: list[int],
+    E: np.ndarray,
+    cache_ids: list[str],
+    configs: list[dict[str, Any]],
+    times: np.ndarray,
+) -> dict[str, Any]:
+    """Build a JSON-serialisable description of a chosen subset.
+
+    Args:
+        selected: Row indices into ``E`` of the selected algorithms.
+        E: Full EPE matrix of the surviving algorithms.
+        cache_ids: Cache ids aligned with ``E`` rows.
+        configs: Full timing-record payloads aligned with ``E`` rows.
+        times: Per-algorithm time stat used for filtering.
+
+    Returns:
+        A dictionary with cost statistics, per-image winners, and a
+        per-selection-entry breakdown.
+    """
+    sub_E = E[selected]
+    per_image_min = sub_E.min(axis=0)
+    per_image_argmin_local = sub_E.argmin(axis=0)
+    per_image_winner_global = np.asarray(selected)[per_image_argmin_local]
+
+    win_counts = np.bincount(per_image_argmin_local, minlength=len(selected))
+
+    entries: list[dict[str, Any]] = []
+    for local_idx, a in enumerate(selected):
+        entries.append(
+            {
+                "cache_id": cache_ids[a],
+                "config": configs[a].get("config", {}),
+                "time_ms": float(times[a]),
+                "win_count": int(win_counts[local_idx]),
+                "mean_epe_solo": float(np.mean(E[a])),
+                "median_epe_solo": float(np.median(E[a])),
+            },
+        )
+
+    return {
+        "selected_indices": [int(a) for a in selected],
+        "selected": entries,
+        "cost_mean": float(np.mean(per_image_min)),
+        "cost_median": float(np.median(per_image_min)),
+        "per_image_winner": [
+            cache_ids[int(a)] for a in per_image_winner_global
+        ],
+        "per_image_min_epe": [float(v) for v in per_image_min],
+    }
+
+
+def _print_selection(label: str, summary: dict[str, Any]) -> None:
+    """Print one solver's selection block.
+
+    Args:
+        label: Header label (e.g. ``"greedy"``).
+        summary: Output of :func:`_summarize_selection`.
+    """
+    print(
+        f"[{label}] cost_mean={summary['cost_mean']:.6f} "
+        f"cost_median={summary['cost_median']:.6f}"
+    )
+    for rank, entry in enumerate(summary["selected"], start=1):
+        cfg = entry["config"]
+        cfg_str = ", ".join(f"{k}={v}" for k, v in cfg.items())
+        print(
+            f"  #{rank} {entry['cache_id']} "
+            f"t={entry['time_ms']:.3f}ms "
+            f"wins={entry['win_count']} "
+            f"mean_solo={entry['mean_epe_solo']:.4f}  [{cfg_str}]",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI.
+
+    Args:
+        argv: Optional explicit argument list (for testing).
+
+    Returns:
+        Process exit code (0 on success).
+
+    Raises:
+        RuntimeError: If too few algorithms survive filtering or if
+            non-finite EPE values remain after the filter step.
+    """
+    args = _parse_args(argv)
+
+    if args.verbose:
+        print(f"loading cache from {args.cache_root}", flush=True)
+    E_all, cache_ids_all, records_all = _load_cache(
+        args.cache_root,
+        args.metric,
+        args.verbose,
+    )
+
+    # Pick the requested time stat per candidate.
+    times_all = np.array(
+        [float(t.get(args.time_stat, float("nan"))) for t in records_all],
+        dtype=np.float64,
+    )
+
+    n0 = E_all.shape[0]
+    finite_mask = np.isfinite(E_all).all(axis=1)
+    n_dropped_nonfinite = int((~finite_mask).sum())
+
+    # The time bound is opt-in: with an infinite limit, candidates without
+    # a timing.json (NaN stat) are kept. A finite limit drops them.
+    if math.isfinite(args.time_limit):
+        time_mask = times_all <= args.time_limit
+    else:
+        time_mask = np.ones_like(finite_mask)
+    keep_mask = finite_mask & time_mask
+    n_dropped_time = int(((~time_mask) & finite_mask).sum())
+
+    print(f"loaded {n0} candidates from {args.cache_root}")
+    print(f"  dropped {n_dropped_nonfinite} with non-finite {args.metric}")
+    print(
+        f"  dropped {n_dropped_time} above --time-limit={args.time_limit} "
+        f"on {args.time_stat}",
+    )
+    n_kept = int(keep_mask.sum())
+    print(f"  kept {n_kept} surviving candidates")
+
+    if n_kept < args.K:
+        raise RuntimeError(
+            f"only {n_kept} candidates survived, cannot pick K={args.K}",
+        )
+
+    kept_idx = np.flatnonzero(keep_mask)
+    E = E_all[kept_idx]
+    times = times_all[kept_idx]
+    cache_ids = [cache_ids_all[i] for i in kept_idx]
+    configs = [records_all[i] for i in kept_idx]
+
+    if not np.isfinite(E).all():
+        raise RuntimeError(
+            f"non-finite {args.metric} survived filtering; "
+            "this indicates a bug",
+        )
+
+    print(
+        f"K={args.K} metric={args.metric} aggregator={args.aggregator} "
+        f"time_stat={args.time_stat} time_limit={args.time_limit}",
+    )
+
+    print("running greedy...")
+    greedy_local = _greedy_select(E, args.K, args.aggregator, args.verbose)
+    greedy_summary = _summarize_selection(
+        greedy_local,
+        E,
+        cache_ids,
+        configs,
+        times,
+    )
+    _print_selection("greedy", greedy_summary)
+
+    exact_summary: dict[str, Any] | None = None
+    exact_status: str | None = None
+    if args.exact:
+        if args.aggregator != "mean":
+            print(
+                "note: --exact is only supported for --aggregator mean in v1; "
+                "skipping MILP and using greedy result.",
+            )
+        else:
+            print(
+                f"running exact MILP (HiGHS, timeout={args.milp_timeout}s)...",
+            )
+            exact_local, status_msg, sum_obj = _exact_milp(
+                E,
+                args.K,
+                args.milp_timeout,
+                args.verbose,
+            )
+            exact_status = status_msg
+            print(f"  HiGHS {status_msg}")
+            if exact_local is None:
+                print(
+                    "WARNING: MILP did not return an integer solution; "
+                    "falling back to greedy.",
+                )
+            else:
+                exact_summary = _summarize_selection(
+                    exact_local,
+                    E,
+                    cache_ids,
+                    configs,
+                    times,
+                )
+                _print_selection("exact", exact_summary)
+                if sum_obj is not None:
+                    obj_mean = sum_obj / float(E.shape[1])
+                    print(
+                        f"  MILP sum-objective={sum_obj:.6f}  "
+                        f"(mean={obj_mean:.6f})"
+                    )
+
+    if exact_summary is not None:
+        agg_key = "cost_mean" if args.aggregator == "mean" else "cost_median"
+        g_cost = greedy_summary[agg_key]
+        e_cost = exact_summary[agg_key]
+        if e_cost > 0:
+            gap = (g_cost - e_cost) / e_cost * 100.0
+        else:
+            gap = float("nan")
+        print(
+            f"gap[{args.aggregator}] greedy={g_cost:.6f} "
+            f"exact={e_cost:.6f}  -> {gap:.4f}%",
+        )
+
+    if args.out is not None:
+        payload: dict[str, Any] = {
+            "solver": "exact+greedy" if exact_summary is not None else "greedy",
+            "K": args.K,
+            "time_limit": args.time_limit,
+            "time_stat": args.time_stat,
+            "aggregator": args.aggregator,
+            "kept_n": n_kept,
+            "dropped_nonfinite": n_dropped_nonfinite,
+            "dropped_time": n_dropped_time,
+            "greedy": greedy_summary,
+        }
+        if exact_summary is not None:
+            payload["exact"] = exact_summary
+            payload["exact_status"] = exact_status
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        print(f"wrote {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/select_ensemble.py
+++ b/scripts/select_ensemble.py
@@ -10,9 +10,13 @@ The script picks a subset ``S`` (|S| = K) that minimizes the aggregator
 
     cost(S) = aggregator_i( min_{a in S} e_{a, i} ),
 
-optionally subject to a per-candidate inference-time bound. A greedy
-solver runs always; an exact MILP (HiGHS via :func:`scipy.optimize.milp`)
-is available for the mean aggregator with ``--exact``.
+optionally subject to a per-candidate inference-time bound. The greedy
+solver runs always and supports both aggregators. An exact MILP (HiGHS
+via :func:`scipy.optimize.milp`) is available with ``--exact`` for the
+mean aggregator only: the MILP objective is the linear sum
+``sum_{a,i} e_{a,i} y_{a,i}`` (the mean up to the constant ``1/M``),
+whereas the median is a non-linear order statistic the assignment LP
+cannot express, so ``--exact`` is a no-op for ``--aggregator median``.
 
 Timing is optional: a candidate only needs a ``timing.json`` when a
 finite ``--time-limit`` is requested (timing is device-dependent and
@@ -41,33 +45,6 @@ import yaml
 from scipy.optimize import Bounds, LinearConstraint, milp
 from scipy.sparse import csr_matrix
 
-# DIS serializes its `preset` enum by name in get_config()/timing.json, but
-# the estimator constructor only accepts an int (or PresetType). Map known
-# names back to ints so exported configs re-load directly.
-_PRESET_NAME_TO_INT = {
-    "ULTRAFAST": 0,
-    "FAST": 1,
-    "MEDIUM": 2,
-    "HIGH_QUALITY": 3,
-}
-
-
-def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
-    """Coerce serialized enum values back to a re-loadable form.
-
-    Args:
-        config: A candidate's stored estimator config.
-
-    Returns:
-        A shallow copy with a string ``preset`` mapped to its int value
-        (other values are left untouched).
-    """
-    cfg = dict(config)
-    preset = cfg.get("preset")
-    if isinstance(preset, str) and preset in _PRESET_NAME_TO_INT:
-        cfg["preset"] = _PRESET_NAME_TO_INT[preset]
-    return cfg
-
 
 def _export_models(
     summary: dict[str, Any],
@@ -79,9 +56,15 @@ def _export_models(
 
     The output is the ``estimators:`` format consumed by
     ``collect_cache.py --estimators-list``, so a chosen subset can be
-    re-collected on other splits (train/val/test) directly. Candidates
-    whose cache stored no ``config`` (e.g. caches written with only a
-    ``meta.json``) are skipped.
+    re-collected on other splits (train/val/test) directly. Each config is
+    emitted verbatim, so re-loading it is the estimator's responsibility
+    (e.g. the DIS estimator accepts its ``preset`` enum name directly).
+
+    The per-candidate ``config`` is read from each candidate's
+    ``timing.json`` (an externally-supplied schema; the in-repo cache
+    writer emits only a ``meta.json`` with ``cache_id``/``version``/
+    ``spec`` and no ``config``). Candidates whose cache stored no
+    ``config`` are skipped.
 
     Args:
         summary: A selection summary from :func:`_summarize_selection`.
@@ -105,7 +88,7 @@ def _export_models(
                 "name": entry["cache_id"],
                 "estimator": estimator,
                 "estimate_type": estimate_type,
-                "config": _normalize_config(config),
+                "config": config,
             }
         )
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -168,7 +151,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--exact",
         action="store_true",
-        help="Run exact MILP after greedy (only supported for mean).",
+        help="Run exact MILP after greedy to refine its selection. Only "
+        "the mean aggregator is supported (the MILP minimizes the linear "
+        "sum = mean); --exact is a no-op for --aggregator median.",
     )
     parser.add_argument(
         "--milp-timeout",
@@ -188,7 +173,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Write the selected subset's configs as an estimators_list "
         "YAML (consumable by collect_cache.py --estimators-list) to "
-        "re-collect on other splits.",
+        "re-collect on other splits. Each config is read from the "
+        "candidate's timing.json (external schema); candidates without a "
+        "stored config are skipped.",
     )
     parser.add_argument(
         "--export-estimator",
@@ -725,8 +712,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.exact:
         if args.aggregator != "mean":
             print(
-                "note: --exact is only supported for --aggregator mean in v1; "
-                "skipping MILP and using greedy result.",
+                "note: --exact supports only --aggregator mean (the MILP "
+                "minimizes the linear sum = mean; the median is a non-linear "
+                "order statistic); skipping MILP and using greedy result.",
             )
         else:
             print(

--- a/scripts/select_ensemble.py
+++ b/scripts/select_ensemble.py
@@ -41,6 +41,33 @@ import yaml
 from scipy.optimize import Bounds, LinearConstraint, milp
 from scipy.sparse import csr_matrix
 
+# DIS serializes its `preset` enum by name in get_config()/timing.json, but
+# the estimator constructor only accepts an int (or PresetType). Map known
+# names back to ints so exported configs re-load directly.
+_PRESET_NAME_TO_INT = {
+    "ULTRAFAST": 0,
+    "FAST": 1,
+    "MEDIUM": 2,
+    "HIGH_QUALITY": 3,
+}
+
+
+def _normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Coerce serialized enum values back to a re-loadable form.
+
+    Args:
+        config: A candidate's stored estimator config.
+
+    Returns:
+        A shallow copy with a string ``preset`` mapped to its int value
+        (other values are left untouched).
+    """
+    cfg = dict(config)
+    preset = cfg.get("preset")
+    if isinstance(preset, str) and preset in _PRESET_NAME_TO_INT:
+        cfg["preset"] = _PRESET_NAME_TO_INT[preset]
+    return cfg
+
 
 def _export_models(
     summary: dict[str, Any],
@@ -78,7 +105,7 @@ def _export_models(
                 "name": entry["cache_id"],
                 "estimator": estimator,
                 "estimate_type": estimate_type,
-                "config": config,
+                "config": _normalize_config(config),
             }
         )
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/flowgym/flow/dis/dis_jax.py
+++ b/src/flowgym/flow/dis/dis_jax.py
@@ -45,7 +45,7 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
 
     def __init__(
         self,
-        preset: PresetType | int = 1,
+        preset: PresetType | int | str = 1,
         start_level: int = 0,
         levels: int = 4,
         level_steps: int = 1,
@@ -63,6 +63,9 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
 
         Args:
             preset: DIS preset (0=ultrafast,1=fast,2=medium,3=high_quality).
+                Accepts the int, a ``PresetType``, or its enum name (e.g.
+                ``"FAST"``) so a config round-tripped through
+                :meth:`get_config` re-loads directly.
             start_level: Starting level for the pyramid.
             levels: Number of levels for the pyramid.
             level_steps: Number of steps between levels.
@@ -78,10 +81,20 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
 
         Raises:
             ValueError: If parameter validation fails.
-            TypeError: If preset is neither int nor PresetType.
+            TypeError: If preset is not an int, str, or PresetType.
         """
-        # Validate and convert preset
-        if isinstance(preset, int):
+        # Validate and convert preset. A str is treated as an enum name
+        # (PresetType.name, as emitted by get_config) so configs round-trip.
+        if isinstance(preset, str):
+            try:
+                preset_enum = PresetType[preset]
+            except KeyError:
+                preset_names = ", ".join(e.name for e in PresetType)
+                raise ValueError(
+                    f"preset={preset!r}, but a string preset must name a "
+                    f"PresetType ({preset_names})"
+                ) from None
+        elif isinstance(preset, int):
             try:
                 preset_enum = PresetType(preset)
             except ValueError:
@@ -96,7 +109,7 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
             preset_enum = preset
         else:
             raise TypeError(
-                f"preset={preset}, but it must be an int or PresetType."
+                f"preset={preset}, but it must be an int, str, or PresetType."
             )
 
         self.preset = preset_enum
@@ -211,7 +224,14 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
         self,
         steps: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
-        """Preload learned-oracle checkpoints to keep runtime jittable."""
+        """Preload learned-oracle checkpoints to keep runtime jittable.
+
+        Args:
+            steps: Postprocessing step descriptors to scan and preload.
+
+        Returns:
+            The steps with learned-oracle state materialized in place.
+        """
         from flowgym.flow.postprocess.data_validation import (  # noqa: PLC0415
             preload_learned_oracle_state,
         )
@@ -353,7 +373,11 @@ class DISJAXFlowFieldEstimator(FlowFieldEstimator):
         }
 
     def supports_jit(self) -> bool:
-        """Disable JIT only if learned-oracle state is not preloaded."""
+        """Disable JIT only if learned-oracle state is not preloaded.
+
+        Returns:
+            True unless a learned-oracle step lacks preloaded state.
+        """
         for step in self.postprocessing_steps:
             if (
                 step.keywords.get("name") == "learned_oracle_threshold"

--- a/src/flowgym/run_setup.py
+++ b/src/flowgym/run_setup.py
@@ -21,6 +21,44 @@ from flowgym.utils import dump_yaml, load_configuration
 logger = gg.get_logger("flowgym", with_metrics=True)
 
 
+def apply_cache_cli_overrides(
+    caching_config: dict | None,
+    cache_root: str | None,
+    cache_id: str | None,
+) -> dict | None:
+    """Override the cache ``root_dir`` / ``cache_id`` from CLI flags.
+
+    The cache ``spec`` stays declarative in the dataset config; these
+    flags only redirect where a cache lands and how it is named, so one
+    dataset config can fill many caches (e.g. one per estimator in a sweep).
+
+    Args:
+        caching_config: Parsed caching block from the dataset config, or
+            None when the dataset declares no caching.
+        cache_root: Override for the cache root directory, or None.
+        cache_id: Override for the base cache id, or None.
+
+    Returns:
+        The (possibly updated) caching config.
+
+    Raises:
+        ValueError: If an override is given but the dataset config has no
+            caching block to supply the required ``spec``.
+    """
+    if cache_root is None and cache_id is None:
+        return caching_config
+    if caching_config is None:
+        raise ValueError(
+            "--cache-root/--cache-id require a `caching:` block (with at "
+            "least a `spec`) in the dataset config."
+        )
+    if cache_root is not None:
+        caching_config["root_dir"] = str(cache_root)
+    if cache_id is not None:
+        caching_config["cache_id"] = cache_id
+    return caching_config
+
+
 def prepare_configs(
     args: argparse.Namespace,
 ) -> tuple[
@@ -155,6 +193,14 @@ def prepare_configs(
                 shape = tuple(v[1])
                 parsed_spec[k] = (dtype_str, shape)
             caching_config["spec"] = parsed_spec
+
+    # CLI flags override where the cache lands / its base id (spec stays
+    # in the dataset config). Lets one dataset config fill many caches.
+    caching_config = apply_cache_cli_overrides(
+        caching_config,
+        getattr(args, "cache_root", None),
+        getattr(args, "cache_id", None),
+    )
 
     if args.mode == "compare-samplers":
         # create a second sampler to load real images from files

--- a/src/main.py
+++ b/src/main.py
@@ -70,6 +70,23 @@ def parse_args():
         help="Dataset configuration file path.",
     )
 
+    parser.add_argument(
+        "--cache-root",
+        type=str,
+        default=None,
+        help="Override the cache root_dir from the dataset's caching block "
+        "(the block still supplies the spec). Enables filling a cache "
+        "without editing the dataset config.",
+    )
+
+    parser.add_argument(
+        "--cache-id",
+        type=str,
+        default=None,
+        help="Override the base cache_id from the dataset's caching block. "
+        "The estimator-specific suffix is still appended.",
+    )
+
     return parser.parse_args()
 
 

--- a/tests/integration/caching/flow/test_dis_cache.py
+++ b/tests/integration/caching/flow/test_dis_cache.py
@@ -54,6 +54,24 @@ def test_dis_get_config():
     assert "start_level" in config
 
 
+def test_dis_preset_name_round_trips():
+    """A get_config preset name re-loads directly (int/name/enum agree)."""
+    # get_config emits the enum name; the constructor must accept it back.
+    by_name = DISJAXFlowFieldEstimator(preset="FAST")
+    assert by_name.preset is PresetType.FAST
+    by_int = DISJAXFlowFieldEstimator(preset=1)
+    assert by_name.get_config() == by_int.get_config()
+    # Full round-trip: config out -> construct -> same config.
+    reloaded = DISJAXFlowFieldEstimator(**by_name.get_config())
+    assert reloaded.get_config()["preset"] == "FAST"
+
+
+def test_dis_invalid_preset_name_raises():
+    """An unknown string preset is a ValueError, not a silent fallback."""
+    with pytest.raises(ValueError, match="PresetType"):
+        DISJAXFlowFieldEstimator(preset="fast")  # lower-case is not a name
+
+
 def test_dis_enrich(tmp_path):
     """DIS enrich returns an EPE array with the correct shape for each miss."""
     # Setup estimator

--- a/tests/unit/scripts/test_collect_cache.py
+++ b/tests/unit/scripts/test_collect_cache.py
@@ -148,13 +148,30 @@ def test_materialize_drops_name_and_writes_model_yaml(tmp_path: Path) -> None:
     work = tmp_path / "work"
     work.mkdir()
     paths = collect_cache.materialize_model_configs(entries, work)
-    assert [p.name for p in paths] == ["DIS_a.yaml", "DIS_b.yaml"]
+    assert [p.name for p in paths] == ["000_DIS_a.yaml", "001_DIS_b.yaml"]
     model = yaml.safe_load(paths[0].read_text())
     assert model == {
         "estimator": "dis_jax",
         "estimate_type": "flow",
         "config": {"preset": 1, "patch_size": 7},
     }
+
+
+def test_materialize_dedupes_duplicate_names(tmp_path: Path) -> None:
+    """Entries sharing a name get distinct files (idx prefix), not collision."""
+    entries = [
+        {"name": "dup", "estimator": "dis_jax", "config": {"patch_size": 7}},
+        {"name": "dup", "estimator": "dis_jax", "config": {"patch_size": 9}},
+    ]
+    work = tmp_path / "work"
+    work.mkdir()
+    paths = collect_cache.materialize_model_configs(entries, work)
+    # Both entries survive: distinct paths, each carrying its own config.
+    assert len(set(paths)) == 2
+    sizes = {
+        yaml.safe_load(p.read_text())["config"]["patch_size"] for p in paths
+    }
+    assert sizes == {7, 9}
 
 
 def test_main_fans_out_over_estimators_list(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_collect_cache.py
+++ b/tests/unit/scripts/test_collect_cache.py
@@ -1,0 +1,122 @@
+"""Tests for the generic cache-collection sweep wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "collect_cache.py"
+
+_spec = importlib.util.spec_from_file_location("collect_cache", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+collect_cache = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(collect_cache)
+
+
+def test_build_eval_command_basic() -> None:
+    """The command targets main.py eval with the shared cache root."""
+    cmd = collect_cache.build_eval_command(
+        ("uv", "run", "python"),
+        Path("m.yaml"),
+        Path("d.yaml"),
+        Path("caches"),
+    )
+    assert cmd == [
+        "uv",
+        "run",
+        "python",
+        "src/main.py",
+        "--mode",
+        "eval",
+        "--estimator",
+        "m.yaml",
+        "--dataset",
+        "d.yaml",
+        "--cache-root",
+        "caches",
+    ]
+
+
+def test_build_eval_command_with_cache_id() -> None:
+    """A base cache id is forwarded to main.py."""
+    cmd = collect_cache.build_eval_command(
+        (".venv/bin/python",),
+        Path("m.yaml"),
+        Path("d.yaml"),
+        Path("c"),
+        cache_id="base",
+    )
+    assert cmd[0] == ".venv/bin/python"
+    assert cmd[cmd.index("--cache-id") + 1] == "base"
+
+
+def test_main_succeeds_with_noop_runner(tmp_path: Path) -> None:
+    """Loop returns 0 when every per-model run exits cleanly."""
+    m1 = tmp_path / "m1.yaml"
+    m1.write_text("x", encoding="utf-8")
+    m2 = tmp_path / "m2.yaml"
+    m2.write_text("x", encoding="utf-8")
+    d = tmp_path / "d.yaml"
+    d.write_text("y", encoding="utf-8")
+    rc = collect_cache.main(
+        [
+            "--models",
+            str(m1),
+            str(m2),
+            "--dataset",
+            str(d),
+            "--cache-root",
+            str(tmp_path / "c"),
+            "--runner",
+            "true",
+        ]
+    )
+    assert rc == 0
+
+
+def test_main_reports_failure_with_failing_runner(tmp_path: Path) -> None:
+    """A non-zero per-model exit propagates to a non-zero return code."""
+    m = tmp_path / "m.yaml"
+    m.write_text("x", encoding="utf-8")
+    d = tmp_path / "d.yaml"
+    d.write_text("y", encoding="utf-8")
+    rc = collect_cache.main(
+        [
+            "--models",
+            str(m),
+            "--dataset",
+            str(d),
+            "--cache-root",
+            str(tmp_path / "c"),
+            "--runner",
+            "false",
+        ]
+    )
+    assert rc == 1
+
+
+def test_limit_truncates_model_list(tmp_path: Path) -> None:
+    """--limit processes only the first N models."""
+    models = []
+    for i in range(3):
+        p = tmp_path / f"m{i}.yaml"
+        p.write_text("x", encoding="utf-8")
+        models.append(str(p))
+    d = tmp_path / "d.yaml"
+    d.write_text("y", encoding="utf-8")
+    rc = collect_cache.main(
+        [
+            "--models",
+            *models,
+            "--dataset",
+            str(d),
+            "--cache-root",
+            str(tmp_path / "c"),
+            "--runner",
+            "true",
+            "--limit",
+            "1",
+        ]
+    )
+    assert rc == 0

--- a/tests/unit/scripts/test_collect_cache.py
+++ b/tests/unit/scripts/test_collect_cache.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+import yaml
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT = _REPO_ROOT / "scripts" / "collect_cache.py"
 
@@ -94,6 +97,95 @@ def test_main_reports_failure_with_failing_runner(tmp_path: Path) -> None:
         ]
     )
     assert rc == 1
+
+
+def _write_estimators_list(path: Path) -> None:
+    """Write a minimal 2-entry estimators_list YAML."""
+    path.write_text(
+        yaml.dump(
+            {
+                "estimators": [
+                    {
+                        "name": "DIS_a",
+                        "estimator": "dis_jax",
+                        "estimate_type": "flow",
+                        "config": {"preset": 1, "patch_size": 7},
+                    },
+                    {
+                        "name": "DIS_b",
+                        "estimator": "dis_jax",
+                        "estimate_type": "flow",
+                        "config": {"preset": 1, "patch_size": 9},
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_estimators_list_returns_entries(tmp_path: Path) -> None:
+    """The estimators_list loader returns the entry dicts."""
+    lst = tmp_path / "dis_models.yaml"
+    _write_estimators_list(lst)
+    entries = collect_cache.load_estimators_list(lst)
+    assert [e["name"] for e in entries] == ["DIS_a", "DIS_b"]
+
+
+def test_load_estimators_list_rejects_empty(tmp_path: Path) -> None:
+    """A file without an `estimators:` list is rejected."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(yaml.dump({"foo": 1}), encoding="utf-8")
+    with pytest.raises(ValueError, match="estimators"):
+        collect_cache.load_estimators_list(bad)
+
+
+def test_materialize_drops_name_and_writes_model_yaml(tmp_path: Path) -> None:
+    """Each entry becomes a standalone model YAML without the name key."""
+    lst = tmp_path / "dis_models.yaml"
+    _write_estimators_list(lst)
+    entries = collect_cache.load_estimators_list(lst)
+    work = tmp_path / "work"
+    work.mkdir()
+    paths = collect_cache.materialize_model_configs(entries, work)
+    assert [p.name for p in paths] == ["DIS_a.yaml", "DIS_b.yaml"]
+    model = yaml.safe_load(paths[0].read_text())
+    assert model == {
+        "estimator": "dis_jax",
+        "estimate_type": "flow",
+        "config": {"preset": 1, "patch_size": 7},
+    }
+
+
+def test_main_fans_out_over_estimators_list(tmp_path: Path) -> None:
+    """--estimators-list runs one eval per sub-estimator."""
+    lst = tmp_path / "dis_models.yaml"
+    _write_estimators_list(lst)
+    d = tmp_path / "d.yaml"
+    d.write_text("y", encoding="utf-8")
+    rc = collect_cache.main(
+        [
+            "--estimators-list",
+            str(lst),
+            "--dataset",
+            str(d),
+            "--cache-root",
+            str(tmp_path / "c"),
+            "--runner",
+            "true",
+        ]
+    )
+    assert rc == 0
+
+
+def test_requires_a_config_source(tmp_path: Path) -> None:
+    """Neither --models nor --estimators-list is an error."""
+    d = tmp_path / "d.yaml"
+    d.write_text("y", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        collect_cache.main(
+            ["--dataset", str(d), "--cache-root", str(tmp_path / "c")]
+        )
 
 
 def test_limit_truncates_model_list(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_select_ensemble.py
+++ b/tests/unit/scripts/test_select_ensemble.py
@@ -153,6 +153,15 @@ def test_export_models_writes_collectable_estimators_list(
     ]
 
 
+def test_export_normalizes_preset_enum_name(tmp_path: Path) -> None:
+    """A serialized preset name (e.g. FAST) is exported as its int value."""
+    summary = {"selected": [{"cache_id": "a", "config": {"preset": "FAST"}}]}
+    out = tmp_path / "m.yaml"
+    select_ensemble._export_models(summary, out, "dis_jax", "flow")
+    data = yaml.safe_load(out.read_text())
+    assert data["estimators"][0]["config"]["preset"] == 1
+
+
 def test_export_models_end_to_end(tmp_path: Path) -> None:
     """--export-models writes the chosen subset using timing.json configs."""
     keys = [1, 2, 3]

--- a/tests/unit/scripts/test_select_ensemble.py
+++ b/tests/unit/scripts/test_select_ensemble.py
@@ -10,6 +10,7 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT = _REPO_ROOT / "scripts" / "select_ensemble.py"
@@ -113,6 +114,78 @@ def test_works_without_timing_json(tiny_cache: Path) -> None:
     assert E.shape == (3, 4)
     assert set(cache_ids) == {"cand_a", "cand_b", "cand_c"}
     assert all(r.get("mean_ms") is None for r in records)
+
+
+def test_partial_cache_is_dropped_not_fatal(tiny_cache: Path) -> None:
+    """A cache with a minority (incomplete) key set is dropped, not fatal."""
+    # tiny_cache has 3 candidates over keys [10,20,30,40]; add a partial one.
+    _write_candidate(tiny_cache, "cand_partial", [10, 20], [0.0, 0.0])
+    E, cache_ids, _ = select_ensemble._load_cache(
+        tiny_cache, metric="epe", verbose=False
+    )
+    assert E.shape == (3, 4)  # the 4-key majority survives
+    assert "cand_partial" not in cache_ids
+
+
+def test_export_models_writes_collectable_estimators_list(
+    tmp_path: Path,
+) -> None:
+    """Selected configs are exported as a collect_cache estimators_list."""
+    summary = {
+        "selected": [
+            {"cache_id": "a", "config": {"patch_size": 7, "preset": 1}},
+            {"cache_id": "b", "config": {}},  # no stored config -> skipped
+        ]
+    }
+    out = tmp_path / "chosen_models.yaml"
+    written, skipped = select_ensemble._export_models(
+        summary, out, "dis_jax", "flow"
+    )
+    assert (written, skipped) == (1, 1)
+    data = yaml.safe_load(out.read_text())
+    assert data["estimators"] == [
+        {
+            "name": "a",
+            "estimator": "dis_jax",
+            "estimate_type": "flow",
+            "config": {"patch_size": 7, "preset": 1},
+        }
+    ]
+
+
+def test_export_models_end_to_end(tmp_path: Path) -> None:
+    """--export-models writes the chosen subset using timing.json configs."""
+    keys = [1, 2, 3]
+    _write_candidate(
+        tmp_path,
+        "x",
+        keys,
+        [0.0, 5.0, 5.0],
+        timing={"config": {"patch_size": 7}},
+    )
+    _write_candidate(
+        tmp_path,
+        "y",
+        keys,
+        [5.0, 0.0, 0.0],
+        timing={"config": {"patch_size": 9}},
+    )
+    out = tmp_path / "models.yaml"
+    rc = select_ensemble.main(
+        [
+            "--cache-root",
+            str(tmp_path),
+            "--K",
+            "2",
+            "--export-models",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    data = yaml.safe_load(out.read_text())
+    sizes = {e["config"]["patch_size"] for e in data["estimators"]}
+    assert sizes == {7, 9}
+    assert all(e["estimator"] == "dis_jax" for e in data["estimators"])
 
 
 def test_finite_time_limit_without_timing_drops_all(tiny_cache: Path) -> None:

--- a/tests/unit/scripts/test_select_ensemble.py
+++ b/tests/unit/scripts/test_select_ensemble.py
@@ -95,6 +95,86 @@ def test_greedy_selects_complementary_subset(
     assert payload["greedy"]["cost_mean"] == pytest.approx(2.0)
 
 
+def test_exact_matches_known_optimum(tiny_cache: Path, tmp_path: Path) -> None:
+    """--exact returns the known optimum; greedy is already optimal (gap 0)."""
+    out = tmp_path / "result.json"
+    rc = select_ensemble.main(
+        [
+            "--cache-root",
+            str(tiny_cache),
+            "--K",
+            "2",
+            "--exact",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert "exact" in payload
+    # {a,c} and {b,c} both reach the optimum mean 2.0.
+    assert payload["exact"]["cost_mean"] == pytest.approx(2.0)
+    assert {e["cache_id"] for e in payload["exact"]["selected"]} <= {
+        "cand_a",
+        "cand_b",
+        "cand_c",
+    }
+    # Greedy already finds the optimum here, so the greedy/exact gap is 0.
+    assert payload["greedy"]["cost_mean"] == pytest.approx(
+        payload["exact"]["cost_mean"]
+    )
+
+
+@pytest.fixture
+def greedy_suboptimal_cache(tmp_path: Path) -> Path:
+    """Build a cache where greedy is strictly worse than the exact optimum.
+
+    Solo means: cand_a=2.5 (best, greedy's seed), cand_b=cand_c=3.5. After
+    seeding cand_a, greedy adds cand_b for mean 1.75, but the true optimum
+    {cand_b, cand_c} has mean 1.0 -- so the MILP must refine greedy.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        The cache root path.
+    """
+    keys = [1, 2, 3, 4]
+    _write_candidate(tmp_path, "cand_a", keys, [1.0, 1.0, 4.0, 4.0])
+    _write_candidate(tmp_path, "cand_b", keys, [1.0, 6.0, 1.0, 6.0])
+    _write_candidate(tmp_path, "cand_c", keys, [6.0, 1.0, 6.0, 1.0])
+    return tmp_path
+
+
+def test_exact_milp_refines_greedy(
+    greedy_suboptimal_cache: Path, tmp_path: Path
+) -> None:
+    """Greedy init + MILP refinement: the exact pass strictly improves."""
+    out = tmp_path / "result.json"
+    rc = select_ensemble.main(
+        [
+            "--cache-root",
+            str(greedy_suboptimal_cache),
+            "--K",
+            "2",
+            "--exact",
+            "--out",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    greedy_cost = payload["greedy"]["cost_mean"]
+    exact_cost = payload["exact"]["cost_mean"]
+    assert greedy_cost == pytest.approx(1.75)  # greedy seeds the trap cand_a
+    assert exact_cost == pytest.approx(1.0)  # true optimum {cand_b, cand_c}
+    assert exact_cost < greedy_cost  # MILP refines past greedy
+    assert {e["cache_id"] for e in payload["exact"]["selected"]} == {
+        "cand_b",
+        "cand_c",
+    }
+
+
 def test_custom_metric_column(tmp_path: Path) -> None:
     """A non-default metric column is honoured via --metric."""
     keys = [1, 2, 3]
@@ -153,13 +233,17 @@ def test_export_models_writes_collectable_estimators_list(
     ]
 
 
-def test_export_normalizes_preset_enum_name(tmp_path: Path) -> None:
-    """A serialized preset name (e.g. FAST) is exported as its int value."""
+def test_export_preserves_config_verbatim(tmp_path: Path) -> None:
+    """Configs are exported untouched (the selector is algorithm-agnostic).
+
+    A serialized preset name (e.g. FAST) is emitted as-is; re-loading it is
+    the estimator's job (the DIS constructor accepts the enum name).
+    """
     summary = {"selected": [{"cache_id": "a", "config": {"preset": "FAST"}}]}
     out = tmp_path / "m.yaml"
     select_ensemble._export_models(summary, out, "dis_jax", "flow")
     data = yaml.safe_load(out.read_text())
-    assert data["estimators"][0]["config"]["preset"] == 1
+    assert data["estimators"][0]["config"]["preset"] == "FAST"
 
 
 def test_export_models_end_to_end(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_select_ensemble.py
+++ b/tests/unit/scripts/test_select_ensemble.py
@@ -1,0 +1,123 @@
+"""Tests for the generic ensemble selector script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "select_ensemble.py"
+
+_spec = importlib.util.spec_from_file_location("select_ensemble", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+select_ensemble = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(select_ensemble)
+
+
+def _write_candidate(
+    cache_root: Path,
+    cache_id: str,
+    keys: list[int],
+    values: list[float],
+    metric: str = "epe",
+    timing: dict | None = None,
+) -> None:
+    """Write a single candidate's cache directory under ``cache_root``.
+
+    Args:
+        cache_root: Sweep cache root.
+        cache_id: Candidate subdirectory name and recorded cache id.
+        keys: Per-image integer keys.
+        values: Per-image scalar errors aligned with ``keys``.
+        metric: Parquet column name holding the errors.
+        timing: Optional timing payload; when given a ``timing.json`` is
+            written alongside the data shards.
+    """
+    subdir = cache_root / cache_id
+    data_dir = subdir / "data"
+    data_dir.mkdir(parents=True)
+    (subdir / "meta.json").write_text(
+        json.dumps({"cache_id": cache_id, "version": "1.0"}),
+        encoding="utf-8",
+    )
+    table = pa.table(
+        {
+            "key": pa.array(np.asarray(keys, dtype=np.uint64)),
+            metric: pa.array(np.asarray(values, dtype=np.float32)),
+        }
+    )
+    pq.write_table(table, data_dir / "part-0.parquet")
+    if timing is not None:
+        (subdir / "timing.json").write_text(
+            json.dumps(timing), encoding="utf-8"
+        )
+
+
+@pytest.fixture
+def tiny_cache(tmp_path: Path) -> Path:
+    """Build a 3-candidate, 4-image cache with a clear complementary pair.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        The cache root path.
+    """
+    keys = [10, 20, 30, 40]
+    _write_candidate(tmp_path, "cand_a", keys, [1.0, 9.0, 9.0, 9.0])
+    _write_candidate(tmp_path, "cand_b", keys, [9.0, 1.0, 9.0, 9.0])
+    _write_candidate(tmp_path, "cand_c", keys, [5.0, 5.0, 1.0, 1.0])
+    return tmp_path
+
+
+def test_greedy_selects_complementary_subset(
+    tiny_cache: Path, tmp_path: Path
+) -> None:
+    """Greedy picks the pair minimizing mean per-image best error."""
+    out = tmp_path / "result.json"
+    rc = select_ensemble.main(
+        ["--cache-root", str(tiny_cache), "--K", "2", "--out", str(out)]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    chosen = {e["cache_id"] for e in payload["greedy"]["selected"]}
+    # cand_c covers images 3,4 (cost 1); cand_a covers image 1 (cost 1).
+    # {a,c} -> mean([1,5,1,1]) = 2.0 beats {a,b} (5.0) and {b,c} (2.0 tie,
+    # but greedy seeds with the best solo = cand_c then adds cand_a).
+    assert chosen == {"cand_a", "cand_c"}
+    assert payload["greedy"]["cost_mean"] == pytest.approx(2.0)
+
+
+def test_custom_metric_column(tmp_path: Path) -> None:
+    """A non-default metric column is honoured via --metric."""
+    keys = [1, 2, 3]
+    _write_candidate(tmp_path, "x", keys, [0.0, 5.0, 5.0], metric="score")
+    _write_candidate(tmp_path, "y", keys, [5.0, 0.0, 0.0], metric="score")
+    rc = select_ensemble.main(
+        ["--cache-root", str(tmp_path), "--K", "1", "--metric", "score"]
+    )
+    assert rc == 0
+
+
+def test_works_without_timing_json(tiny_cache: Path) -> None:
+    """Candidates without timing.json are usable when no time bound is set."""
+    E, cache_ids, records = select_ensemble._load_cache(
+        tiny_cache, metric="epe", verbose=False
+    )
+    assert E.shape == (3, 4)
+    assert set(cache_ids) == {"cand_a", "cand_b", "cand_c"}
+    assert all(r.get("mean_ms") is None for r in records)
+
+
+def test_finite_time_limit_without_timing_drops_all(tiny_cache: Path) -> None:
+    """A finite time bound drops candidates lacking a timing stat."""
+    with pytest.raises(RuntimeError, match="survived"):
+        select_ensemble.main(
+            ["--cache-root", str(tiny_cache), "--K", "1", "--time-limit", "1.0"]
+        )

--- a/tests/unit/test_cache_cli_overrides.py
+++ b/tests/unit/test_cache_cli_overrides.py
@@ -1,0 +1,37 @@
+"""Tests for CLI overrides of the dataset caching block."""
+
+from __future__ import annotations
+
+import pytest
+
+from flowgym.run_setup import apply_cache_cli_overrides
+
+
+def test_no_override_returns_config_unchanged() -> None:
+    """With no flags the caching config is returned untouched."""
+    cfg = {"root_dir": "a", "cache_id": "b", "spec": {}}
+    assert apply_cache_cli_overrides(cfg, None, None) is cfg
+
+
+def test_override_sets_root_and_id() -> None:
+    """Both flags populate the caching block, leaving the spec intact."""
+    cfg = {"spec": {"epe": ("float32", ())}, "warm_start": "index"}
+    out = apply_cache_cli_overrides(cfg, "/tmp/x", "my_cache")
+    assert out is not None
+    assert out["root_dir"] == "/tmp/x"
+    assert out["cache_id"] == "my_cache"
+    assert out["spec"] == {"epe": ("float32", ())}
+
+
+def test_partial_override_only_touches_given_field() -> None:
+    """A single flag overrides only that field."""
+    cfg = {"root_dir": "keep", "cache_id": "old", "spec": {}}
+    apply_cache_cli_overrides(cfg, None, "new")
+    assert cfg["root_dir"] == "keep"
+    assert cfg["cache_id"] == "new"
+
+
+def test_override_without_caching_block_raises() -> None:
+    """Flags require a caching block (which supplies the spec)."""
+    with pytest.raises(ValueError, match="caching"):
+        apply_cache_cli_overrides(None, "/tmp/x", None)

--- a/uv.lock
+++ b/uv.lock
@@ -649,6 +649,7 @@ dependencies = [
     { name = "jax" },
     { name = "pip" },
     { name = "robo-goggles" },
+    { name = "scipy" },
 ]
 
 [package.optional-dependencies]
@@ -723,6 +724,7 @@ requires-dist = [
     { name = "pyoptflow", marker = "extra == 'other-methods'" },
     { name = "robo-goggles", specifier = ">=0.2.0" },
     { name = "robo-goggles", extras = ["wandb"], marker = "extra == 'wandb'" },
+    { name = "scipy", specifier = ">=1.11.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = "==7.4.7" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = "==2.0.0" },
     { name = "torch", marker = "extra == 'other-methods'", specifier = ">=1.13.1" },


### PR DESCRIPTION
## Summary

Cache collection is already algorithm-agnostic at the framework level —
`src/main.py --mode eval` dispatches through the polymorphic `enrich()` and
`get_cache_id_suffix()`, so DIS/RAFT/openpiv/art_of_piv all flow through one
path. This adds a clean, estimator-agnostic way to fill and consume caches,
**without** a per-algorithm producer script.

- **`src/main.py`**: add `--cache-root` / `--cache-id` flags. A new helper
  `apply_cache_cli_overrides` (`run_setup.py`) injects them into the dataset's
  caching block, so the dataset YAML carries only the `spec` (the one
  genuinely estimator-specific bit) and the same config can fill many caches
  without edits.
- **`scripts/collect_cache.py`** (new): thin sweep wrapper that runs the eval
  once per estimator config into a shared `--cache-root` (subprocess-isolated
  so JIT/GPU memory is released between configs; continue-on-error; end
  summary). No algorithm-specific logic.
- **`scripts/select_ensemble.py`** (new): picks a size-`K` subset minimizing
  the aggregate per-image best error (greedy, plus an exact MILP for the mean
  aggregator with `--exact`). `--metric` selects the parquet error column
  (default `epe`); `timing.json` is optional (timing is device-dependent and
  collected separately from the device-independent error).
- **`docs/examples/caching.md`**: documents the three commands.

## Usage

```bash
# one cache (no YAML edits — spec stays in the dataset config)
uv run python src/main.py --mode eval --estimator e.yaml --dataset d.yaml --cache-root caches/

# sweep many configs into one root
uv run python scripts/collect_cache.py --models estimators/*.yaml --dataset d.yaml --cache-root caches/

# pick a K-subset from the cache
uv run python scripts/select_ensemble.py --cache-root caches/ --K 3 --metric epe
```

## Test plan

- [x] Unit tests (13): `apply_cache_cli_overrides`, `collect_cache.build_eval_command`
      + loop return codes, `select_ensemble` over a tiny on-disk cache (custom
      metric, with/without `timing.json`).
- [x] `ruff`, `ruff format`, `pydoclint`, `basedpyright`, push-stage hooks pass.

## Note

This is the public counterpart of the internal version of the same feature.
The selector is new here (the internal repo's earlier DIS-specific selector
was never mirrored to this fork), so it lands directly in its generalized form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)