### PR TITLE
docs(examples): demo cache + timing + ensemble selection together

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -23,6 +23,11 @@ order most readers will want to follow.
   `examples/11_caching.py`. Cold/warm cache reuse with the DIS and RAFT
   demos. Treat as an advanced optimization topic after the core
   eval/training paths make sense.
+- [Sweep, time, and select an ensemble](sweep-ensemble.md) —
+  `examples/14_cache_sweep_ensemble.py`. Runs `collect_cache.py`,
+  `collect_timing.py`, and `select_ensemble.py` together over a small
+  synthetic sweep: error cache, per-config timing, and a `K`-subset
+  selection that exports a collect-ready config list.
 
 `src/main.py` is the CLI entrypoint these workflows invoke.
 
@@ -36,4 +41,5 @@ flow-eval
 supervised-training
 density-eval
 caching
+sweep-ensemble
 ```

--- a/docs/examples/sweep-ensemble.md
+++ b/docs/examples/sweep-ensemble.md
@@ -1,0 +1,61 @@
+# Sweep, time, and select an ensemble
+
+`examples/14_cache_sweep_ensemble.py` demonstrates the three
+estimator-agnostic sweep tools working together, end to end, on a small
+fully synthetic dataset (no downloads; runs on CPU):
+
+1. **`scripts/collect_cache.py`** — fill a per-image **error** cache for many
+   model configs over one dataset. The error is device-independent, so the
+   cache is reproducible and reusable across machines.
+2. **`scripts/collect_timing.py`** — write a per-config **`timing.json`**
+   (device-dependent inference time, measured `timeit`-style at batch size 1
+   with the input pre-loaded on the device) into the *same* cache dirs.
+3. **`scripts/select_ensemble.py`** — pick a size-`K` subset minimizing the
+   per-image best error, optionally subject to a latency bound, and export
+   the chosen configs as a collect-ready `estimators_list` YAML.
+
+## How to run
+
+```bash
+uv sync --group dev
+uv run python examples/14_cache_sweep_ensemble.py
+```
+
+## What the script does
+
+- builds a tiny synthetic dataset (synthpix generates particle images from a
+  handful of flow fields) with a `caching` block declaring the error `spec`;
+- writes three `dis_jax` model configs differing only in `patch_size`;
+- runs `collect_cache.py` over them, then `collect_timing.py`, then
+  `select_ensemble.py --K 2 --export-models`.
+
+## Why the three are inter-compatible
+
+Each candidate config maps to a single cache directory
+`<cache-root>/<cache_id>/`, where `cache_id` is the base id (from the dataset
+config or `--cache-id-base`) plus the estimator's `get_cache_id_suffix` (a
+hash of its config). `collect_cache.py` writes the error parquet under
+`data/` there; `collect_timing.py` writes `timing.json` there; and
+`select_ensemble.py` reads **both** from that directory. So as long as the two
+collectors share the same `--cache-root` and base id, error and timing land
+together automatically:
+
+```text
+=== cache layout (error + timing co-located per config) ===
+  demo-sweep_c5a09d90c: error=True timing=True
+  demo-sweep_cc712e59d: error=True timing=True
+  demo-sweep_cd0430e37: error=True timing=True
+```
+
+`timing.json` is optional: without a finite `--time-limit`, selection ranks
+purely on the device-independent error and ignores timing entirely.
+
+## Closing the loop
+
+`select_ensemble.py --export-models chosen.yaml` writes the picked subset in
+the `estimators_list` format, which feeds straight back into a full-set run:
+
+```bash
+scripts/collect_cache.py --estimators-list chosen.yaml --dataset full.yaml \
+    --cache-root full_caches/
+```

--- a/examples/14_cache_sweep_ensemble.py
+++ b/examples/14_cache_sweep_ensemble.py
@@ -1,20 +1,9 @@
 """End-to-end demo of the sweep cache / timing / ensemble-selection scripts.
 
-Shows the three estimator-agnostic sweep tools working together on a small,
-fully synthetic dataset (no downloads; runs on CPU):
-
-1. ``scripts/collect_cache.py``   -- fill the per-image **error** cache
-   (device-independent; reusable across machines).
-2. ``scripts/collect_timing.py``  -- write per-config ``timing.json``
-   (device-dependent inference time) into the *same* cache dirs.
-3. ``scripts/select_ensemble.py`` -- pick a size-K subset minimizing the
-   per-image best error, optionally under a latency bound, and export the
-   chosen configs as a collect-ready ``estimators_list`` YAML.
-
-The three are inter-compatible by construction: each config's error parquet
-and its ``timing.json`` land in the same ``<cache-root>/<cache_id>/`` dir
-(``cache_id`` = base + the estimator's ``get_cache_id_suffix``), and
-``select_ensemble`` reads both from there.
+Runs ``collect_cache.py`` -> ``collect_timing.py`` -> ``select_ensemble.py``
+on a small, fully synthetic dataset (no downloads; runs on CPU). See
+``docs/examples/sweep-ensemble.md`` for what each step does and why the
+three tools are inter-compatible.
 
 Run:
 

--- a/examples/14_cache_sweep_ensemble.py
+++ b/examples/14_cache_sweep_ensemble.py
@@ -1,0 +1,209 @@
+"""End-to-end demo of the sweep cache / timing / ensemble-selection scripts.
+
+Shows the three estimator-agnostic sweep tools working together on a small,
+fully synthetic dataset (no downloads; runs on CPU):
+
+1. ``scripts/collect_cache.py``   -- fill the per-image **error** cache
+   (device-independent; reusable across machines).
+2. ``scripts/collect_timing.py``  -- write per-config ``timing.json``
+   (device-dependent inference time) into the *same* cache dirs.
+3. ``scripts/select_ensemble.py`` -- pick a size-K subset minimizing the
+   per-image best error, optionally under a latency bound, and export the
+   chosen configs as a collect-ready ``estimators_list`` YAML.
+
+The three are inter-compatible by construction: each config's error parquet
+and its ``timing.json`` land in the same ``<cache-root>/<cache_id>/`` dir
+(``cache_id`` = base + the estimator's ``get_cache_id_suffix``), and
+``select_ensemble`` reads both from there.
+
+Run:
+
+    uv run python examples/14_cache_sweep_ensemble.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from example_support import (
+    REPO_ROOT,
+    make_flow_files,
+    make_synthetic_dataset_config,
+    write_yaml,
+)
+
+# Three dis_jax configs differing only in patch_size -> three distinct
+# cache_ids (the config hash differs), so they are separate sweep candidates.
+PATCH_SIZES = (7, 9, 11)
+
+
+def dis_config(patch_size: int) -> dict:
+    """Minimal dis_jax model config for a given patch size.
+
+    Args:
+        patch_size: DIS interrogation patch size (also used as the stride).
+
+    Returns:
+        A model config dict ready to serialize as an estimator YAML.
+    """
+    return {
+        "estimator": "dis_jax",
+        "estimate_type": "flow",
+        "config": {
+            "jit": True,
+            "preset": 1,
+            "patch_size": patch_size,
+            "patch_stride": patch_size,
+            "grad_desc_iters": 4,
+            "var_refine_iters": 0,
+            "use_mean_normalization": False,
+            "use_spatial_propagation": False,
+            "use_temporal_propagation": False,
+            "start_level": 0,
+            "levels": 1,
+            "level_steps": 1,
+            "output_full_res": True,
+        },
+    }
+
+
+def run_script(script: str, *args: object) -> subprocess.CompletedProcess[str]:
+    """Run one of the sweep scripts with the current interpreter (CPU env).
+
+    Args:
+        script: Script filename under ``scripts/``.
+        *args: Command-line arguments (stringified).
+
+    Returns:
+        The completed subprocess result.
+
+    Raises:
+        RuntimeError: If the script exits non-zero.
+    """
+    cmd = [sys.executable, str(REPO_ROOT / "scripts" / script)]
+    cmd += [str(a) for a in args]
+    print("$ python", f"scripts/{script}", *(str(a) for a in args))
+    env = os.environ.copy()
+    env.update(
+        {
+            "WANDB_MODE": "offline",
+            "WANDB_API_KEY": "example",
+            "CUDA_VISIBLE_DEVICES": "",
+            "XLA_PYTHON_CLIENT_PREALLOCATE": "false",
+        }
+    )
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, text=True, capture_output=True, check=False, env=env
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise RuntimeError(f"{script} failed (exit {result.returncode}).")
+    return result
+
+
+def main() -> int:
+    """Run the full collect -> time -> select workflow on synthetic data.
+
+    Returns:
+        Process exit code (0 on success).
+    """
+    with tempfile.TemporaryDirectory(prefix="sweep_demo_") as raw_tmp:
+        tmp = Path(raw_tmp)
+
+        # 1. A tiny synthetic dataset (synthpix generates the particle images
+        #    from these flow fields) with a caching block declaring the spec.
+        flows = make_flow_files(tmp / "flows", num_files=4)
+        dataset = make_synthetic_dataset_config(
+            file_list=flows, batch_size=2, num_batches=2
+        )
+        cache_root = tmp / "caches"
+        dataset["caching"] = {
+            "root_dir": str(cache_root),
+            "cache_id": "demo-sweep",
+            "spec": {
+                "epe": ["float32", []],
+                "relative_epe": ["float32", []],
+            },
+            "warm_start": "index",
+        }
+        dataset_path = write_yaml(tmp / "dataset.yaml", dataset)
+
+        # 2. The sweep: one estimator YAML per candidate config.
+        model_paths = [
+            write_yaml(tmp / f"dis_p{ps}.yaml", dis_config(ps))
+            for ps in PATCH_SIZES
+        ]
+
+        print("\n=== 1) collect_cache: per-image error caches ===")
+        run_script(
+            "collect_cache.py",
+            "--models",
+            *model_paths,
+            "--dataset",
+            dataset_path,
+            "--cache-root",
+            cache_root,
+            "--runner",
+            sys.executable,
+        )
+
+        print("\n=== 2) collect_timing: per-config timing.json ===")
+        run_script(
+            "collect_timing.py",
+            "--models",
+            *model_paths,
+            "--dataset",
+            dataset_path,
+            "--cache-root",
+            cache_root,
+            "--iters",
+            20,
+            "--repeat",
+            3,
+        )
+
+        # Each candidate dir now holds BOTH the error parquet and timing.json.
+        print("\n=== cache layout (error + timing co-located per config) ===")
+        for cand in sorted(p for p in cache_root.iterdir() if p.is_dir()):
+            data_dir = cand / "data"
+            has_parquet = data_dir.is_dir() and any(
+                data_dir.glob("part-*.parquet")
+            )
+            has_timing = (cand / "timing.json").is_file()
+            print(f"  {cand.name}: error={has_parquet} timing={has_timing}")
+
+        print("\n=== 3) select_ensemble: pick a K=2 subset ===")
+        chosen = tmp / "chosen_estimators.yaml"
+        result = run_script(
+            "select_ensemble.py",
+            "--cache-root",
+            cache_root,
+            "--K",
+            2,
+            "--metric",
+            "epe",
+            "--export-models",
+            chosen,
+            "--export-estimator",
+            "dis_jax",
+        )
+        print(result.stdout.strip())
+
+        print(f"\nExported chosen subset -> {chosen.name}:")
+        print(chosen.read_text(encoding="utf-8"))
+        print(
+            "Feed that file straight back into a full-set run with\n"
+            "  collect_cache.py --estimators-list chosen_estimators.yaml ..."
+        )
+
+    print("\nDemo complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds **`examples/14_cache_sweep_ensemble.py`** — an end-to-end, CPU-only, fully synthetic demo of the three estimator-agnostic sweep tools working together:

1. `scripts/collect_cache.py` — per-image **error** cache (device-independent)
2. `scripts/collect_timing.py` — per-config **`timing.json`** (device-dependent, `timeit` at bs=1, input pre-loaded on device)
3. `scripts/select_ensemble.py` — pick a `K`-subset minimizing per-image best error (optionally under a latency bound), and `--export-models` the chosen configs as a collect-ready `estimators_list`.

It builds a tiny synthpix dataset (no downloads) and three `dis_jax` configs, then runs collect → time → select, prints the cache layout, and exports the winners.

## Why — demonstrates the three are inter-compatible

Each candidate maps to one cache dir `<cache-root>/<cache_id>/` (`cache_id` = base + the estimator's `get_cache_id_suffix`). `collect_cache` writes the error parquet under `data/`, `collect_timing` writes `timing.json` alongside it, and `select_ensemble` reads both — so with a shared `--cache-root` + base id they land together automatically. The demo prints this explicitly:

```text
=== cache layout (error + timing co-located per config) ===
  demo-sweep_c5a09d90c: error=True timing=True
  demo-sweep_cc712e59d: error=True timing=True
  demo-sweep_cd0430e37: error=True timing=True
```

and the selector consumes the timing (`#1 ... t=0.599ms ...`), then exports a config list that feeds straight back into a full-set `collect_cache --estimators-list` run.

## Docs

`docs/examples/sweep-ensemble.md` (linked from `docs/examples/index.md`).

## Testing

- Runs clean end-to-end via `uv run python examples/14_cache_sweep_ensemble.py` (CPU, ~synthetic, no downloads).
- `ruff` (0.14.1) check + format, `pydoclint`, `basedpyright` all clean on the new example.

Stacked on #70 (base `feat/generic-timing-collector`) because the demo exercises `collect_timing.py` from that PR (which itself stacks on #62). Rebase down the stack as those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)